### PR TITLE
Rename methods and cleanup

### DIFF
--- a/docs/src/PencilArrays.md
+++ b/docs/src/PencilArrays.md
@@ -87,7 +87,7 @@ ManyPencilArray
 ```@docs
 extra_dims(::PencilArray)
 get_comm(::MaybePencilArrayCollection)
-get_permutation(::MaybePencilArrayCollection)
+permutation(::MaybePencilArrayCollection)
 global_view(::PencilArray)
 ndims_extra(::MaybePencilArrayCollection)
 ndims_space(::PencilArray)

--- a/docs/src/PencilArrays_timers.md
+++ b/docs/src/PencilArrays_timers.md
@@ -28,7 +28,7 @@ pencil = Pencil(#= args... =#)
 # [do stuff with `pencil`...]
 
 # Retrieve and print timing data associated to `plan`
-to = get_timer(pencil)
+to = timer(pencil)
 print_timer(to)
 ```
 

--- a/docs/src/Pencils.md
+++ b/docs/src/Pencils.md
@@ -85,9 +85,9 @@ LogicalOrder
 ```@docs
 topology(::Pencil)
 get_comm(::Pencil)
-get_decomposition(::Pencil)
-get_permutation(::Pencil)
-get_timer(::Pencil)
+decomposition(::Pencil)
+permutation(::Pencil)
+timer(::Pencil)
 length(::Pencil)
 ndims(::Pencil)
 range_remote(::Pencil, ::Integer, ::LogicalOrder)

--- a/src/PencilArrays.jl
+++ b/src/PencilArrays.jl
@@ -16,7 +16,7 @@ include("Pencils/Pencils.jl")
 
 import .Pencils:
     get_comm,
-    get_permutation,
+    permutation,
     range_local,
     range_remote,
     size_local,

--- a/src/PencilIO/PencilIO.jl
+++ b/src/PencilIO/PencilIO.jl
@@ -58,9 +58,9 @@ function metadata(x::MaybePencilArrayCollection)
     topo = topology(x)
     edims = extra_dims(x)  # this may be an empty tuple, with no type information
     (
-        permutation = Tuple(get_permutation(x)),
+        permutation = Tuple(permutation(x)),
         extra_dims = SVector{length(edims),Int}(edims),
-        decomposed_dims = get_decomposition(pen),
+        decomposed_dims = decomposition(pen),
         process_dims = size(topo),
     )
 end

--- a/src/PencilIO/hdf5.jl
+++ b/src/PencilIO/hdf5.jl
@@ -169,7 +169,7 @@ function Base.setindex!(
         g::HDF5FileOrGroup, x::MaybePencilArrayCollection,
         name::AbstractString; chunks=false, collective=true, prop_pairs...,
     )
-    to = get_timer(pencil(x))
+    to = timer(pencil(x))
 
     @timeit_debug to "Write HDF5" begin
 
@@ -252,7 +252,7 @@ end
 """
 function Base.read!(g::HDF5FileOrGroup, x::MaybePencilArrayCollection,
                     name::AbstractString; collective=true, prop_pairs...)
-    to = get_timer(pencil(x))
+    to = timer(pencil(x))
 
     @timeit_debug to "Read HDF5" begin
 

--- a/src/PencilIO/mpi_io.jl
+++ b/src/PencilIO/mpi_io.jl
@@ -245,7 +245,7 @@ end
 
 function write_discontiguous(ff::MPI.FileHandle, x::PencilArray;
                              offset, collective, infokws...)
-    to = get_timer(pencil(x))
+    to = timer(pencil(x))
     @timeit_debug to "Write MPI-IO discontiguous" begin
         set_view!(ff, x, offset; infokws...)
         A = parent(x)
@@ -260,7 +260,7 @@ end
 
 function read_discontiguous!(ff::MPI.FileHandle, x::PencilArray;
                              offset, collective, infokws...)
-    to = get_timer(pencil(x))
+    to = timer(pencil(x))
     @timeit_debug to "Read MPI-IO discontiguous" begin
         set_view!(ff, x, offset; infokws...)
         A = parent(x)
@@ -291,7 +291,7 @@ end
 
 function write_contiguous(ff::MPI.FileHandle, x::PencilArray;
                           offset, collective, infokws...)
-    to = get_timer(pencil(x))
+    to = timer(pencil(x))
     @timeit_debug to "Write MPI-IO contiguous" begin
         offset += mpi_io_offset(x)
         A = parent(x)
@@ -306,7 +306,7 @@ end
 
 function read_contiguous!(ff::MPI.FileHandle, x::PencilArray;
                           offset, collective, infokws...)
-    to = get_timer(pencil(x))
+    to = timer(pencil(x))
     @timeit_debug to "Read MPI-IO contiguous" begin
         offset += mpi_io_offset(x)
         A = parent(x)

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -249,10 +249,7 @@ of dimensions.
 """
 range_local(p::Pencil, ::LogicalOrder) = p.axes_local
 range_local(p::Pencil, ::MemoryOrder) = p.axes_local_perm
-
-# TODO in the future, the deprecated function should be replaced by this
-# range_local(p) = range_local(p, DefaultOrder())
-range_local(p; permute=nothing) = range_local(p, _index_order_deprecated(permute))
+range_local(p) = range_local(p, DefaultOrder())
 
 """
     range_remote(p::Pencil, coords, [order = LogicalOrder()])
@@ -277,13 +274,6 @@ range_remote(p, I) = range_remote(p, I, LogicalOrder())
 range_remote(p, I, ::MemoryOrder) =
     permute_indices(range_remote(p, I, LogicalOrder()), permutation(p))
 
-# Deprecations
-_index_order_deprecated(::Nothing) = DefaultOrder()
-function _index_order_deprecated(permute::Bool)
-    Base.depwarn("`permute` argument is deprecated; use LogicalOrder() or MemoryOrder() instead", :pencil_permute)
-    permute ? MemoryOrder() : LogicalOrder()
-end
-
 """
     size_local(p::Pencil, [order = LogicalOrder()])
 
@@ -293,7 +283,6 @@ By default the dimensions are not permuted, i.e. they follow the logical order
 of dimensions.
 """
 size_local(p::Pencil, etc...) = map(length, range_local(p, etc...))
-size_local(p; permute=nothing) = size_local(p, _index_order_deprecated(permute))
 
 """
     size_global(p::Pencil, [order = LogicalOrder()])
@@ -306,8 +295,7 @@ order.
 """
 size_global(p::Pencil, ::LogicalOrder) = p.size_global
 size_global(p::Pencil, ::MemoryOrder) = permute_indices(p.size_global, permutation(p))
-# size_global(p) = size_global(p, DefaultOrder())
-size_global(p; permute=nothing) = size_global(p, _index_order_deprecated(permute))
+size_global(p) = size_global(p, DefaultOrder())
 
 """
     to_local(p::Pencil, global_inds, [order = LogicalOrder()])
@@ -326,8 +314,6 @@ function to_local(p::Pencil{N}, global_inds::ArrayRegion{N},
     end :: ArrayRegion{N}
     order === MemoryOrder() ? permute_indices(ind, permutation(p)) : ind
 end
-
-to_local(p, inds; permute) = to_local(p, inds, _index_order_deprecated(permute))
 
 Permutations.permute_indices(t::Tuple, p::Pencil) = permute_indices(t, permutation(p))
 

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -10,13 +10,18 @@ using TimerOutputs
 export Pencil, MPITopology
 export Permutation, NoPermutation
 export MemoryOrder, LogicalOrder
-export get_decomposition, get_permutation
-export get_comm, get_timer
+export decomposition, permutation
+export get_comm, timer
 export topology
 export range_local, range_remote, size_local, size_global, to_local
 
 # Describes the portion of an array held by a given MPI process.
 const ArrayRegion{N} = NTuple{N,UnitRange{Int}} where N
+
+# Deprecated in v0.4
+@deprecate get_permutation permutation
+@deprecate get_decomposition decomposition
+@deprecate get_timer timer
 
 include("MPITopologies.jl")
 @reexport using .MPITopologies
@@ -71,10 +76,10 @@ each MPI process.
 
     Pencil(
         p::Pencil{N,M};
-        decomp_dims::Dims{M} = get_decomposition(p),
+        decomp_dims::Dims{M} = decomposition(p),
         size_global::Dims{N} = size_global(p),
-        permute::P = get_permutation(p),
-        timer::TimerOutput = get_timer(p),
+        permute::P = permutation(p),
+        timer::TimerOutput = timer(p),
     )
 
 Create new pencil configuration from an existent one.
@@ -136,11 +141,11 @@ struct Pencil{
     end
 
     function Pencil(p::Pencil{N,M};
-                    decomp_dims::Dims{M}=get_decomposition(p),
-                    size_global::Dims{N}=size_global(p),
-                    permute=get_permutation(p),
-                    timer::TimerOutput=get_timer(p),
-                    etc...
+                    decomp_dims::Dims{M} = decomposition(p),
+                    size_global::Dims{N} = size_global(p),
+                    permute = permutation(p),
+                    timer::TimerOutput = timer(p),
+                    etc...,
                    ) where {N, M}
         Pencil(p.topology, size_global, decomp_dims;
                permute=permute, timer=timer,
@@ -169,23 +174,23 @@ end
 _sort_dimensions(dims::Dims{N}) where {N} = Tuple(sort(SVector(dims)))
 
 function Base.show(io::IO, p::Pencil)
-    perm = get_permutation(p)
+    perm = permutation(p)
     print(io,
           """
           Decomposition of $(ndims(p))D data
               Data dimensions: $(size_global(p))
-              Decomposed dimensions: $(get_decomposition(p))
+              Decomposed dimensions: $(decomposition(p))
               Data permutation: $(perm)""")
 end
 
 """
-    get_timer(p::Pencil)
+    timer(p::Pencil)
 
 Get `TimerOutput` attached to a `Pencil`.
 
 See [Measuring performance](@ref PencilArrays.measuring_performance) for details.
 """
-get_timer(p::Pencil) = p.timer
+timer(p::Pencil) = p.timer
 
 """
     ndims(p::Pencil)
@@ -205,20 +210,20 @@ Get MPI communicator associated to an MPI decomposition scheme.
 get_comm(p::Pencil) = get_comm(p.topology)
 
 """
-    get_permutation(p::Pencil)
+    permutation(p::Pencil)
 
 Get index permutation associated to the given pencil configuration.
 
 Returns `NoPermutation()` if there is no associated permutation.
 """
-get_permutation(p::Pencil) = p.perm
+permutation(p::Pencil) = p.perm
 
 """
-    get_decomposition(p::Pencil)
+    decomposition(p::Pencil)
 
 Get tuple with decomposed dimensions of the given pencil configuration.
 """
-get_decomposition(p::Pencil) = p.decomp_dims
+decomposition(p::Pencil) = p.decomp_dims
 
 """
     topology(p::Pencil)

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -275,7 +275,7 @@ range_remote(p::Pencil{N,M}, I::Dims{M}, ::LogicalOrder) where {N,M} =
 range_remote(p, I) = range_remote(p, I, LogicalOrder())
 
 range_remote(p, I, ::MemoryOrder) =
-    permute_indices(range_remote(p, I, LogicalOrder()), p.perm)
+    permute_indices(range_remote(p, I, LogicalOrder()), permutation(p))
 
 # Deprecations
 _index_order_deprecated(::Nothing) = DefaultOrder()
@@ -305,7 +305,7 @@ Like [`size_local`](@ref), by default the returned dimensions are in logical
 order.
 """
 size_global(p::Pencil, ::LogicalOrder) = p.size_global
-size_global(p::Pencil, ::MemoryOrder) = permute_indices(p.size_global, p.perm)
+size_global(p::Pencil, ::MemoryOrder) = permute_indices(p.size_global, permutation(p))
 # size_global(p) = size_global(p, DefaultOrder())
 size_global(p; permute=nothing) = size_global(p, _index_order_deprecated(permute))
 
@@ -324,14 +324,14 @@ function to_local(p::Pencil{N}, global_inds::ArrayRegion{N},
         δ = 1 - first(rl)
         (first(rg) + δ):(last(rg) + δ)
     end :: ArrayRegion{N}
-    order === MemoryOrder() ? permute_indices(ind, p.perm) : ind
+    order === MemoryOrder() ? permute_indices(ind, permutation(p)) : ind
 end
 
 to_local(p, inds; permute) = to_local(p, inds, _index_order_deprecated(permute))
 
-Permutations.permute_indices(t::Tuple, p::Pencil) = permute_indices(t, p.perm)
+Permutations.permute_indices(t::Tuple, p::Pencil) = permute_indices(t, permutation(p))
 
 Permutations.relative_permutation(p::Pencil, q::Pencil) =
-    relative_permutation(p.perm, q.perm)
+    relative_permutation(permutation(p), permutation(q))
 
 end

--- a/src/Transpositions/Transpositions.jl
+++ b/src/Transpositions/Transpositions.jl
@@ -94,7 +94,7 @@ struct Transposition{T, N,
         # The `decomp_dims` tuples of both pencils must differ by at most one
         # value (as just checked by `assert_compatible`). The transposition
         # is performed along the dimension R where that difference happens.
-        dim = findfirst(Pi.decomp_dims .!= Po.decomp_dims)
+        dim = findfirst(decomposition(Pi) .!= decomposition(Po))
 
         reqs = MPI.Request[]
 
@@ -164,11 +164,12 @@ function assert_compatible(p::Pencil, q::Pencil)
     end
     # Check that decomp_dims differ on at most one value.
     # Both are expected to be sorted.
-    @assert all(issorted.((p.decomp_dims, q.decomp_dims)))
-    if sum(p.decomp_dims .!= q.decomp_dims) > 1
+    dp, dq = map(decomposition, (p, q))
+    @assert all(issorted.((dp, dq)))
+    if sum(dp .!= dq) > 1
         throw(ArgumentError(
             "pencil decompositions must differ in at most one dimension. " *
-            "Got decomposed dimensions $(p.decomp_dims) and $(q.decomp_dims)."))
+            "Got decomposed dimensions $dp and $dq."))
     end
     nothing
 end

--- a/src/Transpositions/Transpositions.jl
+++ b/src/Transpositions/Transpositions.jl
@@ -217,7 +217,7 @@ function permute_local!(Ao::PencilArray{T,N},
     Po = pencil(Ao)
 
     perm = let perm_base = relative_permutation(Pi, Po)
-        p = append_to_permutation(perm_base, Val(length(Ai.extra_dims)))
+        p = append_to_permutation(perm_base, Val(ndims_extra(Ai)))
         Tuple(p)
     end
 

--- a/src/Transpositions/Transpositions.jl
+++ b/src/Transpositions/Transpositions.jl
@@ -497,7 +497,7 @@ function transpose_recv!(
 
         # Copy data to `Ao`, permuting dimensions if required.
         @timeit_debug timer "copy_permuted!" copy_permuted!(
-            Ao, o_range_iperm, recv_buf, off, perm, exdims, timer)
+            Ao, o_range_iperm, recv_buf, off, perm, exdims)
     end
 
     Ao
@@ -537,8 +537,7 @@ end
 
 function copy_permuted!(dest::PencilArray{T,N}, o_range_iperm::ArrayRegion{P},
                         src::Vector{T}, src_offset::Int,
-                        perm::Permutation, extra_dims::Dims{E},
-                        timer) where {T,N,P,E}
+                        perm::Permutation, extra_dims::Dims{E}) where {T,N,P,E}
     @assert P + E == N
 
     src_view = let src_dims = (length.(o_range_iperm)..., extra_dims...)

--- a/src/Transpositions/Transpositions.jl
+++ b/src/Transpositions/Transpositions.jl
@@ -15,8 +15,6 @@ abstract type AbstractTransposeMethod end
 struct PointToPoint <: AbstractTransposeMethod end
 struct Alltoallv <: AbstractTransposeMethod end
 
-Base.@deprecate_binding IsendIrecv PointToPoint
-
 function Base.show(io::IO, ::T) where {T<:AbstractTransposeMethod}
     print(io, nameof(T))
 end

--- a/src/Transpositions/Transpositions.jl
+++ b/src/Transpositions/Transpositions.jl
@@ -143,7 +143,7 @@ function transpose!(
 end
 
 function transpose!(t::Transposition; waitall=true)
-    timer = get_timer(t.Pi)
+    timer = Pencils.timer(t.Pi)
     @timeit_debug timer "transpose!" begin
         transpose_impl!(t.dim, t)
         if waitall
@@ -193,7 +193,7 @@ function transpose_impl!(::Nothing, t::Transposition)
     Po = t.Po
     in = t.Ai
     out = t.Ao
-    timer = get_timer(Pi)
+    timer = Pencils.timer(Pi)
 
     # Both pencil configurations are identical, so we just copy the data,
     # permuting dimensions if needed.
@@ -201,7 +201,7 @@ function transpose_impl!(::Nothing, t::Transposition)
     ui = parent(in)
     uo = parent(out)
 
-    if get_permutation(Pi) == get_permutation(Po)
+    if permutation(Pi) == permutation(Po)
         @timeit_debug timer "copy!" copy!(uo, ui)
     else
         @timeit_debug timer "permute_local!" permute_local!(out, in)
@@ -259,7 +259,7 @@ function transpose_impl!(R::Int, t::Transposition{T}) where {T}
     Ai = t.Ai
     Ao = t.Ao
     method = t.method
-    timer = get_timer(Pi)
+    timer = Pencils.timer(Pi)
 
     @assert Pi.topology === Po.topology
     @assert extra_dims(Ai) === extra_dims(Ao)

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -107,11 +107,6 @@ function PencilArray{T}(init, pencil::Pencil, extra_dims::Vararg{Integer}) where
     PencilArray(pencil, Array{T}(init, dims))
 end
 
-@deprecate(
-    PencilArray{T}(init, pencil::Pencil, extra_dims::NTuple) where {T},
-    PencilArray{T}(init, pencil, extra_dims...),
-)
-
 """
     PencilArrayCollection
 

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -95,7 +95,7 @@ struct PencilArray{
                 "Local dimensions of pencil: $(dims_local)."))
         end
 
-        iperm = inverse_permutation(get_permutation(pencil))
+        iperm = inverse_permutation(permutation(pencil))
         space_dims = permute_indices(geom_dims, iperm)
 
         new{T, N, A, Np, E, P}(pencil, data, space_dims, extra_dims)
@@ -179,12 +179,12 @@ size_local(x::MaybePencilArrayCollection, args...; kwargs...) =
 
 # TODO this won't work with extra_dims...
 function Base.axes(x::PencilArray)
-    iperm = inverse_permutation(get_permutation(x))
+    iperm = inverse_permutation(permutation(x))
     permute_indices(axes(parent(x)), iperm)
 end
 
 function Base.similar(x::PencilArray, ::Type{S}, dims::Dims) where {S}
-    perm = get_permutation(x)
+    perm = permutation(x)
     dims_perm = permute_indices(dims, perm)
     PencilArray(x.pencil, similar(x.data, S, dims_perm))
 end
@@ -197,7 +197,7 @@ Base.IndexStyle(::Type{<:PencilArray{T,N,A}} where {T,N}) where {A} =
 # TODO this won't work with extra_dims...
 @inline function Base._sub2ind(x::PencilArray, I...)
     # _sub2ind(axes(x), I...)  <- default implementation for AbstractArray
-    J = permute_indices(I, get_permutation(x))
+    J = permute_indices(I, permutation(x))
     Base._sub2ind(parent(x), J...)
 end
 
@@ -225,7 +225,7 @@ end
     @assert M + E === N
     J = ntuple(n -> I[n], Val(M))
     K = ntuple(n -> I[M + n], Val(E))
-    perm = get_permutation(x)
+    perm = permutation(x)
     (permute_indices(J, perm)..., K...)
 end
 
@@ -253,7 +253,7 @@ Base.dataids(x::PencilArray) = Base.dataids(parent(x))
 # This is based on strides(::PermutedDimsArray)
 function Base.strides(x::PencilArray)
     s = strides(parent(x))
-    permute_indices(s, get_permutation(x))
+    permute_indices(s, permutation(x))
 end
 
 """
@@ -367,15 +367,15 @@ Get MPI communicator associated to a pencil-distributed array.
 get_comm(x::MaybePencilArrayCollection) = get_comm(pencil(x))
 
 """
-    get_permutation(x::PencilArray)
-    get_permutation(x::PencilArrayCollection)
+    permutation(x::PencilArray)
+    permutation(x::PencilArrayCollection)
 
 Get index permutation associated to the given `PencilArray`.
 
 Returns `NoPermutation()` if there is no associated permutation.
 """
-function get_permutation(x::MaybePencilArrayCollection)
-    perm = get_permutation(pencil(x))
+function permutation(x::MaybePencilArrayCollection)
+    perm = permutation(pencil(x))
 
     # Account for extra dimensions.
     E = ndims_extra(x)

--- a/src/cartesian_indices.jl
+++ b/src/cartesian_indices.jl
@@ -48,12 +48,12 @@ end
 end
 
 Base.LinearIndices(A::PencilArray) =
-    PermutedLinearIndices(LinearIndices(parent(A)), get_permutation(A))
+    PermutedLinearIndices(LinearIndices(parent(A)), permutation(A))
 
 function Base.LinearIndices(g::GlobalPencilArray)
     A = parent(g)
     off = g.offsets
-    PermutedLinearIndices(LinearIndices(parent(A)), get_permutation(A), off)
+    PermutedLinearIndices(LinearIndices(parent(A)), permutation(A), off)
 end
 
 # We make CartesianIndices(::PencilArray) return a PermutedCartesianIndices,
@@ -97,11 +97,10 @@ end
 end
 
 Base.CartesianIndices(A::PencilArray) =
-    PermutedCartesianIndices(CartesianIndices(parent(A)), get_permutation(A))
+    PermutedCartesianIndices(CartesianIndices(parent(A)), permutation(A))
 
 function Base.CartesianIndices(g::GlobalPencilArray)
     A = parent(g)
     off = g.offsets .* -1  # negative offsets
-    PermutedCartesianIndices(CartesianIndices(parent(A)), get_permutation(A),
-                             off)
+    PermutedCartesianIndices(CartesianIndices(parent(A)), permutation(A), off)
 end

--- a/src/gather.jl
+++ b/src/gather.jl
@@ -12,7 +12,7 @@ This can be useful for testing, but it shouldn't be used with very large
 datasets!
 """
 function gather(x::PencilArray{T,N}, root::Integer=0) where {T, N}
-    timer = get_timer(pencil(x))
+    timer = Pencils.timer(pencil(x))
 
     @timeit_debug timer "gather" begin
 

--- a/src/gather.jl
+++ b/src/gather.jl
@@ -21,7 +21,7 @@ function gather(x::PencilArray{T,N}, root::Integer=0) where {T, N}
     rank = MPI.Comm_rank(comm)
     mpi_tag = 42
     pen = pencil(x)
-    extra_dims = x.extra_dims
+    extra_dims = PencilArrays.extra_dims(x)
 
     # Each process sends its data to the root process.
     # If the local indices are permuted, the permutation is reverted before

--- a/src/gather.jl
+++ b/src/gather.jl
@@ -26,7 +26,7 @@ function gather(x::PencilArray{T,N}, root::Integer=0) where {T, N}
     # Each process sends its data to the root process.
     # If the local indices are permuted, the permutation is reverted before
     # sending the data.
-    data = let perm = pen.perm
+    data = let perm = permutation(pen)
         if is_identity_permutation(perm)
             x.data
         else

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -86,9 +86,9 @@ version = "0.21.1"
 
 [[JSON3]]
 deps = ["Dates", "Mmap", "Parsers", "StructTypes", "UUIDs"]
-git-tree-sha1 = "f17f647d78ade849298039b75bbd48c05da77900"
+git-tree-sha1 = "9414acd0788bf246c2b948c169bf0ab53ebdeab9"
 uuid = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
-version = "1.4.0"
+version = "1.5.0"
 
 [[LibGit2]]
 deps = ["Printf"]

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -19,7 +19,7 @@ function test_pencil(pen)
     A = PencilArray{Float64}(undef, pen)
     G = global_view(A)
     randn!(A)
-    perm = Tuple(get_permutation(A))
+    perm = Tuple(permutation(A))
 
     @testset "Broadcast $(nameof(typeof(x)))" for x in (A, G)
         test_broadcast(x)

--- a/test/io.jl
+++ b/test/io.jl
@@ -51,7 +51,7 @@ function test_write_mpiio(filename, u::PencilArray)
     # First, gather data from all processes.
     # Note that we may need to permute indices of data, since data on disk is
     # written in memory (not logical) order.
-    perm = Tuple(get_permutation(u))
+    perm = Tuple(permutation(u))
     Xg = map(X) do x
         xg = gather(x, root)  # note: data is in logical order
         xg === nothing && return xg
@@ -147,7 +147,7 @@ function test_write_hdf5(filename, u::PencilArray)
         read!(ff, vr, "scalar_again")
         @test vr == ur
 
-        let perm = Tuple(get_permutation(ur))
+        let perm = Tuple(permutation(ur))
             @test haskey(attributes(ff["scalar"]), "permutation")
             expected = perm === nothing ? false : collect(perm)
             @test read(ff["scalar"]["permutation"]) == expected

--- a/test/pencils.jl
+++ b/test/pencils.jl
@@ -265,7 +265,7 @@ function main()
 
     # Note: the permutation of pen2 was chosen such that the inverse permutation
     # is different.
-    @assert pen2.perm !== PA.inverse_permutation(pen2.perm)
+    @assert permutation(pen2) !== PA.inverse_permutation(permutation(pen2))
 
     @testset "Pencil constructor checks" begin
         # Too many decomposed directions

--- a/test/pencils.jl
+++ b/test/pencils.jl
@@ -31,7 +31,7 @@ end
 
 function test_array_wrappers(p::Pencil, ::Type{T} = Float64) where {T}
     u = PencilArray{T}(undef, p)
-    perm = get_permutation(p)
+    perm = permutation(p)
     let topo = topology(p)
         @test topo === topology(u)
         I = coords_local(topo)
@@ -66,7 +66,7 @@ function test_array_wrappers(p::Pencil, ::Type{T} = Float64) where {T}
     if BENCHMARK_ARRAYS
         for S in (IndexLinear, IndexCartesian)
             @info("Filling arrays using $S (Array, PencilArray, GlobalPencilArray)",
-                  get_permutation(p))
+                  permutation(p))
             for v in (parent(u), u, ug)
                 val = 3 * oneunit(eltype(v))
                 @btime benchmark_fill!($S, $v, $val)
@@ -295,8 +295,8 @@ function main()
     end
 
     @testset "permutations" begin
-        @test get_permutation(pen1) === NoPermutation()
-        @test get_permutation(pen2) === Permutation(2, 3, 1)
+        @test permutation(pen1) === NoPermutation()
+        @test permutation(pen2) === Permutation(2, 3, 1)
 
         @test PA.is_identity_permutation(NoPermutation())
         @test PA.is_identity_permutation(Permutation(1, 2, 3, 4))


### PR DESCRIPTION
- Rename get_permutation -> permutation
- Prefer permutation(p) to p.perm
- Prefer decomposition(p)
- More consistent names in Transpositions
- Avoid A.extra_dims
- Remove unused function argument
- Transpositions: prefer map to broadcast
- Remove old deprecations
