### PR TITLE
PencilIO: support HDF5.jl v0.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   JULIA_MPI_BINARY: system
-  JULIA_HDF5_LIBRARY_PATH: /usr/lib/x86_64-linux-gnu/hdf5/mpich
+  JULIA_HDF5_PATH: /usr/lib/x86_64-linux-gnu/hdf5/mpich
 
 jobs:
   test:

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,4 +5,4 @@ PencilArrays = "0e08944d-e94e-41b1-9406-dcf66b6a9d2e"
 
 [compat]
 Documenter = "0.26"
-HDF5 = "= 0.14.1"
+HDF5 = "0.15"

--- a/docs/src/PencilIO.md
+++ b/docs/src/PencilIO.md
@@ -101,7 +101,9 @@ Optional keyword arguments, such as `collective`, are also supported by
 
 If using the [Parallel HDF5 driver](#PencilArrays.PencilIO.PHDF5Driver), the HDF5.jl package must
 be available and configured with MPI support.
-Note that HDF5.jl versions previous to [v0.15](https://github.com/JuliaIO/HDF5.jl/releases/tag/v0.15.0) are not supported.
+Note that HDF5.jl versions previous to
+[v0.15](https://github.com/JuliaIO/HDF5.jl/releases/tag/v0.15.0) are not
+supported.
 
 Parallel HDF5 is not enabled in the default installation of HDF5.jl.
 For Parallel HDF5 to work, the HDF5 C libraries wrapped by HDF5.jl must be
@@ -141,6 +143,7 @@ directory of the HDF5 libraries compiled with parallel support are found.
 Then run `]build HDF5` from Julia.
 Note that the selected HDF5 library must be linked to the MPI library chosen in
 the previous section.
+Also note that HDF5 library versions older than 0.10.4 are not supported by HDF5.jl.
 For the set-up to be persistent across HDF5.jl updates, consider setting
 `JULIA_HDF5_PATH` in `~/.bashrc` or similar.
 

--- a/docs/src/PencilIO.md
+++ b/docs/src/PencilIO.md
@@ -101,7 +101,7 @@ Optional keyword arguments, such as `collective`, are also supported by
 
 If using the [Parallel HDF5 driver](#PencilArrays.PencilIO.PHDF5Driver), the HDF5.jl package must
 be available and configured with MPI support.
-Note that HDF5.jl versions previous to [v0.14](https://github.com/JuliaIO/HDF5.jl/releases/tag/v0.14.0) are not supported.
+Note that HDF5.jl versions previous to [v0.15](https://github.com/JuliaIO/HDF5.jl/releases/tag/v0.15.0) are not supported.
 
 Parallel HDF5 is not enabled in the default installation of HDF5.jl.
 For Parallel HDF5 to work, the HDF5 C libraries wrapped by HDF5.jl must be
@@ -136,15 +136,15 @@ for details.
 
 ### 2. Using parallel HDF5 libraries
 
-Set the `JULIA_HDF5_LIBRARY_PATH` environment variable to the directory where
-the HDF5 libraries compiled with parallel support are found.
+Set the `JULIA_HDF5_PATH` environment variable to the top-level installation
+directory of the HDF5 libraries compiled with parallel support are found.
 Then run `]build HDF5` from Julia.
 Note that the selected HDF5 library must be linked to the MPI library chosen in
 the previous section.
 For the set-up to be persistent across HDF5.jl updates, consider setting
-`JULIA_HDF5_LIBRARY_PATH` in `~/.bashrc` or similar.
+`JULIA_HDF5_PATH` in `~/.bashrc` or similar.
 
-See the [HDF5.jl docs](https://juliaio.github.io/HDF5.jl/stable/#System-provided-HDF5-libraries) for details.
+See the [HDF5.jl README](https://github.com/JuliaIO/HDF5.jl#installation) for details.
 
 ### 3. Loading PencilIO
 

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -2,9 +2,9 @@
 
 [[ArrayInterface]]
 deps = ["LinearAlgebra", "Requires", "SparseArrays"]
-git-tree-sha1 = "3b5bd474a90bee86b50f26268bbb044bb4d9ef83"
+git-tree-sha1 = "a0c202d58f0f99156bd77972fe75ae8498fd9f4b"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "2.14.9"
+version = "2.14.13"
 
 [[Artifacts]]
 deps = ["Pkg"]
@@ -65,9 +65,9 @@ version = "0.8.3"
 
 [[HDF5]]
 deps = ["Blosc", "Compat", "HDF5_jll", "Libdl", "Mmap", "Random", "Requires"]
-git-tree-sha1 = "96d77533eb46e208e801b939db8a27626c166565"
+git-tree-sha1 = "a7ba439762caed0b98d1c7f00621b8b058c62891"
 uuid = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
-version = "0.14.1"
+version = "0.15.0"
 
 [[HDF5_jll]]
 deps = ["Artifacts", "JLLWrappers", "LibCURL_jll", "Libdl", "OpenSSL_jll", "Pkg", "Zlib_jll"]
@@ -80,9 +80,9 @@ deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JLLWrappers]]
-git-tree-sha1 = "c70593677bbf2c3ccab4f7500d0f4dacfff7b75c"
+git-tree-sha1 = "a431f5f2ca3f4feef3bd7a5e94b8b8d4f2f647a0"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.1.3"
+version = "1.2.0"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -10,4 +10,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-HDF5 = "= 0.14.1"
+HDF5 = "0.15"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,10 +4,10 @@ using InteractiveUtils
 using MPI: MPI, mpiexec
 
 test_files = [
+    "io.jl",
     "pencils.jl",
     "array_interface.jl",
     "broadcast.jl",
-    "io.jl",
 ]
 
 Nproc = let N = get(ENV, "JULIA_MPI_NPROC", nothing)


### PR DESCRIPTION
Also, older HDF5.jl versions are no longer supported.