### PR TITLE
Define fill! for PencilArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PencilArrays"
 uuid = "0e08944d-e94e-41b1-9406-dcf66b6a9d2e"
 authors = ["Juan Ignacio Polanco <jipolanc@gmail.com> and contributors"]
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -455,3 +455,5 @@ permutation(x::PencilArrayCollection) = _apply(permutation, x)
 Get [`MPITopology`](@ref) associated to a `PencilArray`.
 """
 topology(x::MaybePencilArrayCollection) = topology(pencil(x))
+
+Base.fill!(A::PencilArray, x) = fill!(parent(A), x)

--- a/test/pencils.jl
+++ b/test/pencils.jl
@@ -41,6 +41,11 @@ function test_array_wrappers(p::Pencil, ::Type{T} = Float64) where {T}
 
     @test match(r"PencilArray{.*}\(::Pencil{.*}\)", summary(u)) !== nothing
 
+    for x in (42, 10)
+        fill!(u, x)
+        @test all(==(x), u)
+    end
+
     perm = permutation(u)
     @test perm === permutation(typeof(u))
     let topo = topology(p)


### PR DESCRIPTION
We explicitly define `fill!` to make sure that the parent array's `fill!` method is called. This is particularly important for CUDA arrays which provide their own optimised version.