### PR TITLE
Add definition of `zero` for `PencilArray`s

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PencilArrays"
 uuid = "0e08944d-e94e-41b1-9406-dcf66b6a9d2e"
 authors = ["Juan Ignacio Polanco <jipolanc@gmail.com> and contributors"]
-version = "0.9.6"
+version = "0.9.7"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -456,4 +456,9 @@ Get [`MPITopology`](@ref) associated to a `PencilArray`.
 """
 topology(x::MaybePencilArrayCollection) = topology(pencil(x))
 
-Base.fill!(A::PencilArray, x) = fill!(parent(A), x)
+Base.zero(x::PencilArray) = fill!(similar(x), zero(eltype(x)))
+
+function Base.fill!(A::PencilArray, x)
+    fill!(parent(A), x)
+    A
+end

--- a/test/pencils.jl
+++ b/test/pencils.jl
@@ -130,6 +130,15 @@ function test_array_wrappers(p::Pencil, ::Type{T} = Float64) where {T}
         end
     end
 
+    @test fill!(u, 42) === u
+
+    let z = @inferred zero(u)
+        @test all(iszero, z)
+        @test typeof(z) === typeof(u)
+        @test pencil(z) === pencil(u)
+        @test size(z) === size(u)
+    end
+
     let v = similar(u)
         @test typeof(v) === typeof(u)
 


### PR DESCRIPTION
This should fix compatibility issue with DifferentialEquations:
https://discourse.julialang.org/t/trouble-using-pencilarrays-with-differentialequations/61965/2