### PR TITLE
Define `similar(::PencilArray, [T], ::Pencil)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PencilArrays"
 uuid = "0e08944d-e94e-41b1-9406-dcf66b6a9d2e"
 authors = ["Juan Ignacio Polanco <jipolanc@gmail.com> and contributors"]
-version = "0.10.0"
+version = "0.10.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -240,6 +240,46 @@ julia> similar(u, ComplexF32) |> summary
 julia> similar(u, ComplexF32, (4, 3)) |> summary
 "4×3 Matrix{ComplexF32}"
 ```
+
+---
+
+    similar(x::PencilArray, [element_type = eltype(x)], p::Pencil)
+
+Create a `PencilArray` with the decomposition described by the `Pencil` `p`.
+
+This variant is useful for creating, from a `PencilArray` with a decomposition
+`A`, a new `PencilArray` with a decomposition `B`.
+
+# Examples
+
+```jldoctest
+julia> pen_u = Pencil((20, 10, 12), (2, 3), MPI.COMM_WORLD);
+
+julia> u = PencilArray{Float64}(undef, pen_u);
+
+julia> pen_v = Pencil(pen_u; decomp_dims = (1, 3), permute = Permutation(2, 3, 1))
+Decomposition of 3D data
+    Data dimensions: (20, 10, 12)
+    Decomposed dimensions: (1, 3)
+    Data permutation: Permutation(2, 3, 1)
+
+julia> v = similar(u, pen_v);
+
+julia> summary(v)
+"20×10×12 PencilArray{Float64, 3}(::Pencil{3, 2, Permutation{(2, 3, 1), 3}})"
+
+julia> pencil(v) === pen_v
+true
+
+julia> vint = similar(u, Int, pen_v);
+
+julia> summary(vint)
+"20×10×12 PencilArray{Int64, 3}(::Pencil{3, 2, Permutation{(2, 3, 1), 3}})"
+
+julia> pencil(vint) === pen_v
+true
+
+```
 """
 function Base.similar(x::PencilArray, ::Type{S}) where {S}
     dims_perm = permutation(x) * size(x)
@@ -248,6 +288,13 @@ end
 
 Base.similar(x::PencilArray, ::Type{S}, dims::Dims) where {S} =
     similar(parent(x), S, dims)
+
+function Base.similar(x::PencilArray, ::Type{S}, p::Pencil) where {S}
+    dims_mem = (size_local(p, MemoryOrder())..., extra_dims(x)...)
+    PencilArray(p, similar(x.data, S, dims_mem))
+end
+
+Base.similar(x::PencilArray, p::Pencil) = similar(x, eltype(x), p)
 
 # Use same index style as the parent array.
 Base.IndexStyle(::Type{<:PencilArray{T,N,A}} where {T,N}) where {A} =

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -245,10 +245,10 @@ julia> similar(u, ComplexF32, (4, 3)) |> summary
 
     similar(x::PencilArray, [element_type = eltype(x)], p::Pencil)
 
-Create a `PencilArray` with the decomposition described by the `Pencil` `p`.
+Create a `PencilArray` with the decomposition described by the given `Pencil`.
 
-This variant is useful for creating, from a `PencilArray` with a decomposition
-`A`, a new `PencilArray` with a decomposition `B`.
+This variant may be used to create a `PencilArray` that has a different
+decomposition than the input `PencilArray`.
 
 # Examples
 

--- a/test/pencils.jl
+++ b/test/pencils.jl
@@ -128,6 +128,23 @@ function test_array_wrappers(p::Pencil, ::Type{T} = Float64) where {T}
             @test z isa DummyArray{Float32,3}
             @test size(z) == (3, 4, 2)
         end
+
+        # Test similar(u, [T], q::Pencil)
+        let N = ndims(p)
+            permute = Permutation(N, ntuple(identity, N - 1)...)  # = (N, 1, 2, ..., N - 1)
+            decomp_dims = mod1.(decomposition(p) .+ 1, N)
+            q = Pencil(p; decomp_dims = decomp_dims, permute = permute)
+
+            v = @inferred similar(u, q)
+            @test pencil(v) === q
+            @test eltype(v) === eltype(u)
+            @test size_global(v) === size_global(u)
+
+            w = @inferred similar(u, Int, q)
+            @test pencil(w) === q
+            @test eltype(w) === Int
+            @test size_global(w) === size_global(u)
+        end
     end
 
     @test fill!(u, 42) === u

--- a/test/pencils.jl
+++ b/test/pencils.jl
@@ -483,8 +483,11 @@ function main()
         pen3 = Pencil(pen2, permute=Permutation(3, 2, 1))
 
         u1 = PencilArray{T}(undef, pen1)
-        u2 = PencilArray{T}(undef, pen2)
-        u3 = PencilArray{T}(undef, pen3)
+        u2 = @inferred similar(u1, pen2)
+        u3 = @inferred similar(u1, pen3)
+
+        @test pencil(u2) === pen2
+        @test pencil(u3) === pen3
 
         randn!(rng, u1)
         transpose!(u2, u1)
@@ -499,7 +502,7 @@ function main()
         @test compare_distributed_arrays(u1, u2)
 
         let v = similar(u2)
-            @test u2.pencil === v.pencil
+            @test pencil(u2) === pencil(v)
             transpose!(v, u2)
             @test compare_distributed_arrays(u1, v)
         end
@@ -525,7 +528,7 @@ function main()
         @inferred PencilArray{T}(undef, pen2, 3, 4)
 
         u1 = PencilArray{T}(undef, pen1)
-        u2 = PencilArray{T}(undef, pen2)
+        u2 = similar(u1, pen2)
 
         @inferred Nothing gather(u2)
         @inferred transpose!(u2, u1)


### PR DESCRIPTION
This adds a an additional definition of `similar` that takes a `PencilArray` and a `Pencil`. This is meant to create arrays in a
different decomposition than the one of the original array.