### PR TITLE
Implement `mapreduce` for `PencilArray`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -36,6 +36,9 @@ function main()
                 "PencilIO.md",
                 "PencilArrays_timers.md",
             ],
+            "Additional notes" => [
+                "notes/reductions.md",
+            ],
         ],
         linkcheck = false,
     )

--- a/docs/src/notes/reductions.md
+++ b/docs/src/notes/reductions.md
@@ -1,0 +1,45 @@
+# Reductions
+
+Reduction over [`PencilArray`](@ref)s using Julia functions such as `minimum`,
+`maximum` or `sum` are performed on the global data.
+This involves first a local reduction over each process, followed by a global
+reduction of a scalar quantity using
+[`MPI.Allreduce`](https://juliaparallel.github.io/MPI.jl/latest/collective/#MPI.Allreduce).
+
+For example:
+
+```julia
+using MPI
+using PencilArrays
+
+MPI.Init()
+
+comm = MPI.COMM_WORLD
+nprocs = MPI.Comm_size(comm)
+rank = MPI.Comm_rank(comm)
+id = rank + 1
+
+pen = Pencil((16, 32, 14), comm)
+u = PencilArray{Int}(undef, pen)
+fill!(u, 2 * id)
+
+minimum(u)  # = 2
+maximum(u)  # = 2 * nprocs
+
+minimum(abs2, u)  # = 4
+maximum(abs2, u)  # = (2 * nprocs)^2
+
+```
+
+!!! note "Note on associativity"
+
+    Associative reduction operations like
+    [`foldl`](https://docs.julialang.org/en/v1/base/collections/#Base.foldl-Tuple{Any,%20Any}),
+    [`foldr`](https://docs.julialang.org/en/v1/base/collections/#Base.foldr-Tuple{Any,%20Any}),
+    [`mapfoldl`](https://docs.julialang.org/en/v1/base/collections/#Base.mapfoldl-Tuple{Any,%20Any,%20Any})
+    and
+    [`mapfoldr`](https://docs.julialang.org/en/v1/base/collections/#Base.mapfoldr-Tuple{Any,%20Any,%20Any})
+    are also defined for consistency, but these operations are not
+    guaranteed to strictly respect left or right associativity.
+    In fact, associativity is only respected on each local process, before
+    results are reduced among all processes.

--- a/src/PencilArrays.jl
+++ b/src/PencilArrays.jl
@@ -35,6 +35,7 @@ include("cartesian_indices.jl")  # PermutedLinearIndices, PermutedCartesianIndic
 
 include("array_interface.jl")
 include("broadcast.jl")
+include("reductions.jl")
 include("gather.jl")
 
 include("Transpositions/Transpositions.jl")

--- a/src/reductions.jl
+++ b/src/reductions.jl
@@ -1,0 +1,5 @@
+# We force specialisation on each function to avoid (tiny) allocations.
+function Base.mapreduce(f::F, op::OP, u::PencilArray; kws...) where {F, OP}
+    rlocal = mapreduce(f, op, parent(u); kws...)
+    MPI.Allreduce(rlocal, op, get_comm(u))
+end

--- a/src/reductions.jl
+++ b/src/reductions.jl
@@ -1,5 +1,15 @@
 # We force specialisation on each function to avoid (tiny) allocations.
-function Base.mapreduce(f::F, op::OP, u::PencilArray; kws...) where {F, OP}
-    rlocal = mapreduce(f, op, parent(u); kws...)
-    MPI.Allreduce(rlocal, op, get_comm(u))
+#
+# Note that, for mapreduce, we can assume that the operation is commutative,
+# which allows MPI to freely reorder operations.
+#
+# We also define mapfoldl (and mapfoldr) for completeness, even though the global
+# operations are not strictly performed from left to right (or from right to
+# left), since each process locally reduces first.
+for (func, commutative) in [:mapreduce => true, :mapfoldl => false, :mapfoldr => false]
+    @eval function Base.$func(f::F, op::OP, u::PencilArray; kws...) where {F, OP}
+        rlocal = $func(f, op, parent(u); kws...)
+        op_mpi = MPI.Op(op, typeof(rlocal); iscommutative = $commutative)
+        MPI.Allreduce(rlocal, op_mpi, get_comm(u))
+    end
 end

--- a/test/reductions.jl
+++ b/test/reductions.jl
@@ -1,0 +1,23 @@
+using MPI
+using PencilArrays
+using Test
+
+MPI.Initialized() || MPI.Init()
+
+comm = MPI.COMM_WORLD
+nprocs = MPI.Comm_size(comm)
+rank = MPI.Comm_rank(comm)
+myid = rank + 1
+
+pen = Pencil((16, 32, 14), comm)
+u = PencilArray{Int32}(undef, pen1)
+fill!(u, 2myid)
+
+@testset "Reductions" begin
+    @test minimum(u) == 2
+    @test maximum(u) == 2nprocs
+    @test minimum(abs2, u) == 2^2
+    @test maximum(abs2, u) == (2nprocs)^2
+    @test sum(u) === MPI.Allreduce(sum(parent(u)), +, comm)
+    @test sum(abs2, u) === MPI.Allreduce(sum(abs2, parent(u)), +, comm)
+end

--- a/test/reductions.jl
+++ b/test/reductions.jl
@@ -20,4 +20,10 @@ fill!(u, 2myid)
     @test maximum(abs2, u) == (2nprocs)^2
     @test sum(u) === MPI.Allreduce(sum(parent(u)), +, comm)
     @test sum(abs2, u) === MPI.Allreduce(sum(abs2, parent(u)), +, comm)
+
+    @test foldl(min, u) === minimum(u)
+    @test mapfoldl(abs2, min, u) === minimum(abs2, u)
+
+    @test foldr(min, u) === minimum(u)
+    @test mapfoldr(abs2, min, u) === minimum(abs2, u)
 end

--- a/test/reductions.jl
+++ b/test/reductions.jl
@@ -21,6 +21,8 @@ fill!(u, 2myid)
     @test sum(u) === MPI.Allreduce(sum(parent(u)), +, comm)
     @test sum(abs2, u) === MPI.Allreduce(sum(abs2, parent(u)), +, comm)
 
+    # These exact equalities work because we're using integers.
+    # They are not guaranteed to work with floats.
     @test foldl(min, u) === minimum(u)
     @test mapfoldl(abs2, min, u) === minimum(abs2, u)
 

--- a/test/reductions.jl
+++ b/test/reductions.jl
@@ -10,7 +10,7 @@ rank = MPI.Comm_rank(comm)
 myid = rank + 1
 
 pen = Pencil((16, 32, 14), comm)
-u = PencilArray{Int32}(undef, pen1)
+u = PencilArray{Int32}(undef, pen)
 fill!(u, 2myid)
 
 @testset "Reductions" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,10 +10,11 @@ using PencilArrays
 include("permutations.jl")
 
 test_files = [
+    "reductions.jl",
+    "broadcast.jl",
     "arrays.jl",
     "pencils.jl",
     "array_interface.jl",
-    "broadcast.jl",
     "io.jl",
 ]
 


### PR DESCRIPTION
Reductions are now global, calling `MPI.Allreduce` with a scalar argument behind the scenes.