### PR TITLE
use VersionParsing to parse non-semver versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StaticPermutations = "15972242-4b8f-49a0-b8a1-9ac0e7a1a45d"
 Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
+VersionParsing = "81def892-9a0e-5fdd-b105-ffc91e053289"
 
 [compat]
 ArrayInterface = "4"

--- a/src/PencilIO/mpi_io.jl
+++ b/src/PencilIO/mpi_io.jl
@@ -1,6 +1,6 @@
 export MPIIODriver
 
-import JSON3
+import JSON3, VersionParsing
 
 # Version of internal MPIIO format.
 # If the version is updated, it should match the upcoming PencilArrays version.
@@ -111,14 +111,8 @@ Base.seek(ff::MPIFile, pos) = ff.position = pos
 
 mpiio_version(ff::MPIFile) = mpiio_version(metadata(ff))
 
-function mpiio_version(meta::MetadataDict)
-    ver = meta[:driver][:version]
-    if ver isa Int  # this is for version ≤ 0.3
-        VersionNumber(string(ver))
-    else
-        VersionNumber(ver)
-    end
-end
+mpiio_version(meta::MetadataDict) =
+    VersionParsing.vparse(string(meta[:driver][:version]))
 
 """
     open([f::Function], driver::MPIIODriver, filename, comm::MPI.Comm; keywords...)


### PR DESCRIPTION
I noticed that you were using the `VersionNumber` constructor to parse the MPIIO version string, which may not be in semver format; you might want to use VersionParsing instead.