### PR TITLE
Bring back support for ArrayInterface.jl v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PencilArrays"
 uuid = "0e08944d-e94e-41b1-9406-dcf66b6a9d2e"
 authors = ["Juan Ignacio Polanco <jipolanc@gmail.com> and contributors"]
-version = "0.13.1"
+version = "0.13.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -19,7 +19,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 VersionParsing = "81def892-9a0e-5fdd-b105-ffc91e053289"
 
 [compat]
-ArrayInterface = "4"
+ArrayInterface = "3, 4"
 JSON3 = "1.4"
 MPI = "0.19"
 OffsetArrays = "1"

--- a/src/array_interface.jl
+++ b/src/array_interface.jl
@@ -15,7 +15,8 @@ contiguous_axis(::Type{A}) where {A <: PencilArray} =
         permutation(A),
     )
 
-_contiguous_axis(x::Missing, ::AbstractPermutation) = x
+_contiguous_axis(x::Nothing, ::AbstractPermutation) = x  # ArrayInterface v3 (to be removed)
+_contiguous_axis(x::Missing, ::AbstractPermutation) = x  # ArrayInterface v4
 _contiguous_axis(x::StaticInt, ::NoPermutation) = x
 @inline function _contiguous_axis(x::StaticInt{i}, p::Permutation) where {i}
     i == -1 && return x
@@ -27,7 +28,8 @@ contiguous_batch_size(::Type{A}) where {A <: PencilArray} =
 
 function stride_rank(::Type{A}) where {A <: PencilArray}
     rank = stride_rank(parent_type(A))
-    rank === missing && return missing
+    rank === nothing && return nothing  # ArrayInterface v3 (to be removed)
+    rank === missing && return missing  # ArrayInterface v4
     iperm = Tuple(inv(permutation(A)))
     iperm === nothing && return rank
     ArrayInterface.permute(rank, Val(iperm))
@@ -35,7 +37,8 @@ end
 
 function dense_dims(::Type{A}) where {A <: PencilArray}
     dense = dense_dims(parent_type(A))
-    dense === missing && return missing
+    dense === nothing && return nothing  # ArrayInterface v3 (to be removed)
+    dense === missing && return missing  # ArrayInterface v4
     perm = Tuple(inv(permutation(A)))
     perm === nothing && return dense
     ArrayInterface.permute(dense, Val(perm))

--- a/test/array_interface.jl
+++ b/test/array_interface.jl
@@ -67,7 +67,7 @@ function test_array_interface(pen_in::Pencil)
         u = PencilArray(p, up)
 
         @test ArrayInterface.parent_type(u) === typeof(up)
-        @test ArrayInterface.known_length(u) === missing
+        @test ArrayInterface.known_length(u) === missing  # assume ArrayInterface version ≥ 4
         @test !ArrayInterface.can_change_size(u)
         @test ArrayInterface.ismutable(u)
         @test ArrayInterface.can_setindex(u)


### PR DESCRIPTION
Otherwise OrdinaryDiffEq.jl can't be installed with the latest PencilArrays.jl. The former uses Polyester.jl which for now needs ArrayInterface.jl v3.
