### PR TITLE
Improve broadcasting on GPU arrays

### DIFF
--- a/docs/src/PencilArrays.md
+++ b/docs/src/PencilArrays.md
@@ -71,6 +71,12 @@ For more details, see for instance [the gradient
 example](https://jipolanco.github.io/PencilFFTs.jl/stable/examples/gradient/#gradient_method_global)
 in the PencilFFTs docs.
 
+!!! warning "Global views"
+
+    Regular `PencilArray`s have more functionality than global view wrappers.
+    This includes broadcasting, which is currently not supported for global views.
+    In general it should be preferred to work with `PencilArray`s.
+
 ## Types
 
 ```@docs

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -25,12 +25,8 @@ _actual_parent(bc::PencilArrayBroadcastable) = _actual_parent(bc.data)
 
 Broadcast.broadcastable(x::PencilArray) = PencilArrayBroadcastable(x)
 
-Base.axes(bc::PencilArrayBroadcastable{PencilArray}) = axes(_actual_parent(bc))
 Base.eltype(::Type{<:PencilArrayBroadcastable{T}}) where {T} = T
-Base.ndims(::Type{<:PencilArrayBroadcastable{T, N}}) where {T, N} = N
 Base.size(bc::PencilArrayBroadcastable) = size(_actual_parent(bc))
-Base.@propagate_inbounds Base.getindex(bc::PencilArrayBroadcastable, inds...) =
-    _actual_parent(bc)[inds...]
 
 function Broadcast.materialize!(u::PencilArray, bc_in::Broadcasted)
     dest = _actual_parent(u)
@@ -79,9 +75,8 @@ function Base.similar(
     A = br.data
     axs_a = permutation(A) * axes(A)  # in memory order
     axs_b = axes(bc)
-    if axs_a ≠ axs_b
+    axs_a == axs_b ||
         throw(DimensionMismatch("arrays cannot be broadcast; got axes $axs_a and $axs_b"))
-    end
     similar(A, T)
 end
 

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -1,42 +1,56 @@
-using Base.Broadcast: BroadcastStyle, ArrayStyle, DefaultArrayStyle, Broadcasted
+using Base.Broadcast:
+    BroadcastStyle, Broadcasted, AbstractArrayStyle, DefaultArrayStyle
 
-for PA in (PencilArray, GlobalPencilArray)
-    @eval begin
-        BroadcastStyle(::Type{<:$PA}) = ArrayStyle{$PA}()
+abstract type AbstractPencilArrayStyle{N} <: AbstractArrayStyle{N} end
 
-        function Base.similar(bc::Broadcasted{ArrayStyle{$PA}}, ::Type{T}) where {T}
-            A = find_pa(bc)
-            if axes(bc) != axes(A)
-                throw(DimensionMismatch("arrays cannot be broadcast; got axes $(axes(bc)) and $(axes(A))"))
-            end
-            similar(A, T)
-        end
+struct PencilArrayStyle{N} <: AbstractPencilArrayStyle{N} end
+struct GlobalPencilArrayStyle{N} <: AbstractPencilArrayStyle{N} end
 
-        find_pa(A::$PA, rest) = A
+BroadcastStyle(::Type{<:PencilArray{T, N}}) where {T, N} =
+    PencilArrayStyle{N}()
+
+# PencilArrayStyle wins against other array styles
+BroadcastStyle(style::AbstractPencilArrayStyle, ::AbstractArrayStyle) = style
+
+# Needed to avoid ambiguities
+BroadcastStyle(
+    style::AbstractPencilArrayStyle{N}, ::DefaultArrayStyle{N},
+) where {N} = style
+
+BroadcastStyle(::Type{<:GlobalPencilArray{T, N}}) where {T, N} =
+    GlobalPencilArrayStyle{N}()
+
+function Base.similar(
+        bc::Broadcasted{<:AbstractPencilArrayStyle}, ::Type{T},
+    ) where {T}
+    A = find_pa(bc)
+    if axes(bc) != axes(A)
+        throw(DimensionMismatch("arrays cannot be broadcast; got axes $(axes(bc)) and $(axes(A))"))
     end
+    similar(A, T)
 end
-
-# Make PencilArray and GlobalPencilArray incompatible for broadcasting.
-# Without this, broadcasting will work with 1 MPI process, but fail with more
-# (with an error by OffsetArrays), which is annoying when testing code.
-function BroadcastStyle(
-        ::ArrayStyle{GlobalPencilArray},
-        ::ArrayStyle{A},
-    ) where {A <: AbstractArray}
-    throw(ArgumentError("cannot combine $A and GlobalPencilArray in broadcast"))
-end
-
-# For the same reasons, disallow broadcasting between generic array and
-# GlobalPencilArray.
-function BroadcastStyle(::ArrayStyle{GlobalPencilArray}, ::DefaultArrayStyle)
-    throw(ArgumentError("cannot combine generic arrays and GlobalPencilArray in broadcast"))
-end
-
-# Exception: broadcasting with scalars.
-BroadcastStyle(style::ArrayStyle{GlobalPencilArray}, ::DefaultArrayStyle{0}) = style
 
 # Find PencilArray or GlobalPencilArray among broadcast arguments.
 find_pa(bc::Broadcasted) = find_pa(bc.args)
 find_pa(args::Tuple) = find_pa(find_pa(args[1]), Base.tail(args))
 find_pa(x) = x
 find_pa(::Any, rest) = find_pa(rest)
+find_pa(A::Union{PencilArray, GlobalPencilArray}, rest) = A
+
+# Make PencilArray and GlobalPencilArray incompatible for broadcasting.
+# Without this, broadcasting will work with 1 MPI process, but fail with more
+# (with an error by OffsetArrays), which is annoying when testing code.
+function BroadcastStyle(::GlobalPencilArrayStyle, ::PencilArrayStyle)
+    throw(ArgumentError(
+        "cannot combine PencilArray and GlobalPencilArray in broadcast"
+    ))
+end
+
+# For the same reasons, disallow broadcasting between generic array and
+# GlobalPencilArray.
+function BroadcastStyle(::GlobalPencilArrayStyle, ::AbstractArrayStyle)
+    throw(ArgumentError("cannot combine generic arrays and GlobalPencilArray in broadcast"))
+end
+
+# Exception: broadcasting with scalars.
+BroadcastStyle(style::GlobalPencilArrayStyle, ::AbstractArrayStyle{0}) = style

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -1,24 +1,79 @@
+# The broadcasting logic is quite tricky due to possible dimension permutations.
+# The basic idea is that, when permutations are enabled, PencilArrays broadcast
+# using their dimensions in memory order.
+# This allows things like `u .+ parent(u)` even when `u` is a PencilArray with
+# permuted dimensions.
+# In this case, `u` and `parent(u)` may have different sizes [e.g. `(4, 6, 7)`
+# vs `(6, 7, 4)`] but they're still allowed to broadcast, which may not be very
+# natural or intuitive.
+
 using Base.Broadcast:
-    BroadcastStyle, Broadcasted, AbstractArrayStyle, DefaultArrayStyle
+    Broadcast,
+    BroadcastStyle, Broadcasted,
+    AbstractArrayStyle, DefaultArrayStyle
 
 abstract type AbstractPencilArrayStyle{N} <: AbstractArrayStyle{N} end
 
 struct PencilArrayStyle{N} <: AbstractPencilArrayStyle{N} end
 struct GlobalPencilArrayStyle{N} <: AbstractPencilArrayStyle{N} end
 
-BroadcastStyle(::Type{<:PencilArray{T, N}}) where {T, N} =
-    PencilArrayStyle{N}()
+struct PencilArrayBroadcastable{T, N, A <: Union{PencilArray, GlobalPencilArray}}
+    data :: A
+    PencilArrayBroadcastable(u::AbstractArray{T, N}) where {T, N} =
+        new{T, N, typeof(u)}(u)
+end
 
-# PencilArrayStyle wins against other array styles
+_actual_parent(u::PencilArray) = parent(u)
+_actual_parent(u::GlobalPencilArray) = parent(parent(u))
+_actual_parent(bc::PencilArrayBroadcastable) = _actual_parent(bc.data)
+
+Broadcast.broadcastable(x::Union{PencilArray, GlobalPencilArray}) =
+    PencilArrayBroadcastable(x)
+
+Base.axes(bc::PencilArrayBroadcastable{Union{PencilArray, GlobalPencilArray}}) =
+    axes(_actual_parent(bc))
+Base.ndims(::Type{PencilArrayBroadcastable{T, N}}) where {T, N} = N
+Base.size(bc::PencilArrayBroadcastable) = size(_actual_parent(bc))
+Base.@propagate_inbounds Base.getindex(bc::PencilArrayBroadcastable, inds...) =
+    _actual_parent(bc)[inds...]
+Base.@propagate_inbounds Base.setindex!(bc::PencilArrayBroadcastable, args...) =
+    setindex!(_actual_parent(bc), args...)
+Base.similar(bc::PencilArrayBroadcastable, ::Type{T}) where {T} =
+    PencilArrayBroadcastable(similar(bc.data, T))
+
+function Broadcast.materialize!(
+        u::Union{PencilArray, GlobalPencilArray},
+        bc::Broadcasted,
+    )
+    Broadcast.materialize!(_actual_parent(u), bc)
+    u
+end
+
+function Broadcast.materialize(bc::Broadcasted{<:AbstractPencilArrayStyle})
+    u = copy(Broadcast.instantiate(bc)) :: PencilArrayBroadcastable
+    u.data
+end
+
+BroadcastStyle(::Type{<:PencilArrayBroadcastable{T, N, <:PencilArray}}) where {T, N} =
+    PencilArrayStyle{N}()
+BroadcastStyle(::Type{<:PencilArrayBroadcastable{T, N, <:GlobalPencilArray}}) where {T, N} =
+    GlobalPencilArrayStyle{N}()
+
+# AbstractPencilArrayStyle wins against other array styles
 BroadcastStyle(style::AbstractPencilArrayStyle, ::AbstractArrayStyle) = style
 
-# Needed to avoid ambiguities
-BroadcastStyle(
-    style::AbstractPencilArrayStyle{N}, ::DefaultArrayStyle{N},
-) where {N} = style
+# This is needed to avoid ambiguities
+BroadcastStyle(style::AbstractPencilArrayStyle, ::DefaultArrayStyle) = style
 
-BroadcastStyle(::Type{<:GlobalPencilArray{T, N}}) where {T, N} =
-    GlobalPencilArrayStyle{N}()
+# TODO can this be allowed?
+# Make PencilArray and GlobalPencilArray incompatible for broadcasting.
+# Without this, broadcasting will work with 1 MPI process, but fail with more
+# (with an error by OffsetArrays), which is annoying when testing code.
+function BroadcastStyle(::GlobalPencilArrayStyle, ::PencilArrayStyle)
+    throw(ArgumentError(
+        "cannot combine PencilArray and GlobalPencilArray in broadcast"
+    ))
+end
 
 function Base.similar(
         bc::Broadcasted{<:AbstractPencilArrayStyle}, ::Type{T},
@@ -35,22 +90,32 @@ find_pa(bc::Broadcasted) = find_pa(bc.args)
 find_pa(args::Tuple) = find_pa(find_pa(args[1]), Base.tail(args))
 find_pa(x) = x
 find_pa(::Any, rest) = find_pa(rest)
-find_pa(A::Union{PencilArray, GlobalPencilArray}, rest) = A
+find_pa(A::PencilArrayBroadcastable, rest) = A
 
-# Make PencilArray and GlobalPencilArray incompatible for broadcasting.
-# Without this, broadcasting will work with 1 MPI process, but fail with more
-# (with an error by OffsetArrays), which is annoying when testing code.
-function BroadcastStyle(::GlobalPencilArrayStyle, ::PencilArrayStyle)
-    throw(ArgumentError(
-        "cannot combine PencilArray and GlobalPencilArray in broadcast"
-    ))
+# When materialising the broadcast, we unwrap all arrays wrapped by PencilArrays.
+# This is to make sure that the right `copyto!` is called.
+# For GPU arrays, this enables the use of the `copyto!` implementation in
+# GPUArrays.jl, avoiding scalar indexing.
+function Base.copyto!(dest_in::PencilArray, bc_in::Broadcasted{Nothing})
+    dest = _unwrap_pa(dest_in)
+    perm = permutation(dest_in)
+    bc = _unwrap_pa(bc_in, perm)
+    @show bc
+    copyto!(dest, bc)
+    dest_in
 end
 
-# For the same reasons, disallow broadcasting between generic array and
-# GlobalPencilArray.
-function BroadcastStyle(::GlobalPencilArrayStyle, ::AbstractArrayStyle)
-    throw(ArgumentError("cannot combine generic arrays and GlobalPencilArray in broadcast"))
+function _unwrap_pa(bc::Broadcasted{Nothing}, perm)
+    args = map(_unwrap_pa, bc.args)
+    axs = perm * axes(bc)  # apply possible permutation
+    Broadcasted{Nothing}(bc.f, args, axs)
 end
 
-# Exception: broadcasting with scalars.
-BroadcastStyle(style::GlobalPencilArrayStyle, ::AbstractArrayStyle{0}) = style
+_unwrap_pa(u::PencilArray) = parent(u)
+_unwrap_pa(u::GlobalPencilArray) = _unwrap_pa(parent(u))
+_unwrap_pa(u) = u
+
+function Base.copyto!(dest::GlobalPencilArray, bc::Broadcasted{Nothing})
+    copyto!(parent(dest), bc)
+    dest
+end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -26,16 +26,15 @@ pencils = (
 
 @testset "$s" for (s, pen) in pencils
     A = PencilArray{Float64}(undef, pen)
-    G = global_view(A)
     randn!(A)
     perm = permutation(A)
 
-    @testset "Broadcast $(nameof(typeof(x)))" for x in (A, G)
+    @testset "Broadcast" begin
         @test typeof(2A) == typeof(A)
         @test typeof(A .+ A) == typeof(A)
         @test typeof(A .+ A .+ 3) == typeof(A)
         @test parent(2A) == 2parent(A)
-        let y = similar(x)
+        let x = A, y = similar(x)
             broadcast!(+, y, x, x, 3)  # precompile before measuring allocations
             alloc = @allocated broadcast!(+, y, x, x, 3)
             @test alloc == 0
@@ -48,15 +47,6 @@ pencils = (
         P = parent(A) :: Array
         @test typeof(P .+ A) == typeof(A)
         @test P .+ A == 2A
-
-        # Combine PencilArray and GlobalPencilArray
-        @test_throws ArgumentError A .+ G
-        # @test typeof(A .+ G) == typeof(G .+ A) == typeof(A)  # PencilArray wins
-        # @test A .+ G == 2A
-
-        # Combine Array and GlobalPencilArray
-        @test typeof(P .+ G) == typeof(G) == typeof(2G)
-        @test P .+ G == 2G
     end
 
     @testset "GPU arrays" begin

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -3,10 +3,9 @@ using PencilArrays
 using Random
 using Test
 
-# TODO test this?
-# using GPUArrays
-# include("include/jlarray.jl")
-# using .JLArrays
+using GPUArrays
+include("include/jlarray.jl")
+using .JLArrays
 
 MPI.Init()
 
@@ -58,5 +57,28 @@ pencils = (
         # Combine Array and GlobalPencilArray
         @test typeof(P .+ G) == typeof(G) == typeof(2G)
         @test P .+ G == 2G
+    end
+
+    @testset "GPU arrays" begin
+        pp = Pencil(JLArray, pen)
+        u = PencilArray{Float32}(undef, pp)
+        randn!(u)
+
+        # Some basic stuff that should work without scalar indexing
+        # (Nothing to do with broadcasting though...)
+        v = @test_nowarn copy(u)
+        @test typeof(v) === typeof(u)
+        @test_nowarn v == u
+        @test v == u
+        @test v ≈ u
+
+        @test parent(u) isa JLArray
+        @test_nowarn u .+ u  # should avoid scalar indexing
+        @test u .+ u == 2u
+        @test typeof(u .+ u) == typeof(u)
+
+        @test_nowarn v .= u .+ 2u
+        @test typeof(v) == typeof(u)
+        @test parent(v) ≈ 3parent(u)
     end
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1,34 +1,45 @@
-#!/usr/bin/env julia
-
 using MPI
 using PencilArrays
 using Random
 using Test
 
+# TODO test this?
+# using GPUArrays
+# include("include/jlarray.jl")
+# using .JLArrays
+
 MPI.Init()
 
 comm = MPI.COMM_WORLD
 rank = MPI.Comm_rank(comm)
-Nproc = MPI.Comm_size(comm)
+rank == 0 || redirect_stdout(devnull)
 
-let dev_null = @static Sys.iswindows() ? "nul" : "/dev/null"
-    rank == 0 || redirect_stdout(open(dev_null, "w"))
-end
+topo = MPITopology(comm, Val(1))
 
-function test_pencil(pen)
+dims = (11, 12, 2)
+perm = Permutation(2, 3, 1)
+@assert inv(perm) != perm
+
+pencils = (
+    "Non-permuted" => Pencil(topo, dims, (2, )),
+    "Permuted" => Pencil(topo, dims, (2, ); permute = perm),
+)
+
+@testset "$s" for (s, pen) in pencils
     A = PencilArray{Float64}(undef, pen)
     G = global_view(A)
     randn!(A)
-    perm = Tuple(permutation(A))
+    perm = permutation(A)
 
     @testset "Broadcast $(nameof(typeof(x)))" for x in (A, G)
-        test_broadcast(x)
+        @test typeof(2A) == typeof(A)
+        @test typeof(A .+ A) == typeof(A)
+        @test typeof(A .+ A .+ 3) == typeof(A)
+        @test parent(2A) == 2parent(A)
         let y = similar(x)
             broadcast!(+, y, x, x, 3)  # precompile before measuring allocations
             alloc = @allocated broadcast!(+, y, x, x, 3)
-            if VERSION ≥ v"1.5"  # there are small allocations in Julia 1.3
-                @test alloc == 0
-            end
+            @test alloc == 0
             @test y ≈ 2x .+ 3
         end
     end
@@ -36,32 +47,16 @@ function test_pencil(pen)
     @testset "Combinations" begin
         # Combine with regular Array
         P = parent(A) :: Array
-        P′ = perm === nothing ? P : PermutedDimsArray(P, perm)
-        @test typeof(P′ .+ A) == typeof(A)
+        @test typeof(P .+ A) == typeof(A)
+        @test P .+ A == 2A
 
         # Combine PencilArray and GlobalPencilArray
         @test_throws ArgumentError A .+ G
+        # @test typeof(A .+ G) == typeof(G .+ A) == typeof(A)  # PencilArray wins
+        # @test A .+ G == 2A
 
         # Combine Array and GlobalPencilArray
-        @test_throws ArgumentError P .+ G
+        @test typeof(P .+ G) == typeof(G) == typeof(2G)
+        @test P .+ G == 2G
     end
-end
-
-function test_broadcast(A)
-    @test typeof(2A) == typeof(A)
-    @test typeof(A .+ A) == typeof(A)
-    @test typeof(A .+ A .+ 3) == typeof(A)
-    @test parent(2A) == 2parent(A)
-    nothing
-end
-
-topo = MPITopology(comm, (Nproc, ))
-
-pencils = (
-    "Non-permuted" => Pencil(topo, (11, 12), (2, )),
-    "Permuted" => Pencil(topo, (11, 12), (2, ), permute=Permutation(2, 1)),
-)
-
-@testset "$s" for (s, pen) in pencils
-    test_pencil(pen)
 end


### PR DESCRIPTION
We make sure that broadcasting with GPU arrays avoids scalar indexing.

This also changes a bit the logic when broadcasting `PencilArray`s and other types of arrays, such that `PencilArray`s always broadcast in contiguous memory order. In other words, when broadcasting, the size of a `PencilArray` is the one given by `size_local(::PencilArray, MemoryOrder())`. This is only relevant when one is working with index permutations, and when one is combining `PencilArray`s and other kinds of arrays (such as base `Array`s) in a single broadcast.

Closes #42.
