### PR TITLE
Add tools for working with local grids

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PencilArrays"
 uuid = "0e08944d-e94e-41b1-9406-dcf66b6a9d2e"
 authors = ["Juan Ignacio Polanco <jipolanc@gmail.com> and contributors"]
-version = "0.14.1"
+version = "0.15.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/README.md
+++ b/README.md
@@ -36,16 +36,18 @@ provides efficient and highly scalable distributed FFTs.
 
 - decomposition of arrays along an arbitrary subset of dimensions;
 
+- tools for conveniently and efficiently iterating over the coordinates of distributed multidimensional geometries;
+
 - transpositions between different decomposition configurations, using
   point-to-point and collective MPI communications;
 
-- zero-cost, convenient dimension permutations using [StaticPermutations](https://github.com/jipolanco/StaticPermutations.jl);
+- zero-cost, convenient dimension permutations using the [StaticPermutations.jl](https://github.com/jipolanco/StaticPermutations.jl) package;
 
 - convenient parallel I/O using either MPI-IO or the [Parallel
   HDF5](https://portal.hdfgroup.org/display/HDF5/Parallel+HDF5) libraries;
 
 - distributed FFTs and related transforms via the
-  [PencilFFTs](https://github.com/jipolanco/PencilFFTs.jl) package.
+  [PencilFFTs.jl](https://github.com/jipolanco/PencilFFTs.jl) package.
 
 ## Installation
 
@@ -85,6 +87,21 @@ parent(Ax)           # parent array holding the local data (here, an Array{Float
 size(Ax)             # total size of the array = (42, 31, 29)
 size_local(Ax)       # size of local part, e.g. (42, 8, 10) for a given process
 range_local(Ax)      # range of local part on global grid, e.g. (1:42, 16:23, 20:29)
+
+# Let's associate the dimensions to a global grid of coordinates (x_i, y_j, z_k)
+xs_global = range(0, 1;  length = dims_global[1])
+ys_global = range(0, 2;  length = dims_global[2])
+zs_global = range(0, 2π; length = dims_global[3])
+
+# Part of the grid associated to the local MPI process:
+grid = localgrid(pen_x, (xs_global, ys_global, zs_global))
+
+# This is convenient for example if we want to initialise the `Ax` array as
+# a function of the grid coordinates (x, y, z):
+@. Ax = grid.x + (2 * grid.y * cos(grid.z))
+
+# Alternatively (useful in higher dimensions):
+@. Ax = grid[1] + (2 * grid[2] * cos(grid[3]))
 
 # Create another pencil configuration, decomposing along dimensions (1, 3).
 # We could use the same constructor as before, but it's recommended to reuse the

--- a/benchmarks/Manifest.toml
+++ b/benchmarks/Manifest.toml
@@ -1,0 +1,326 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.7.2"
+manifest_format = "2.0"
+
+[[deps.Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "af92965fb30777147966f58acb05da51c5616b5f"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "3.3.3"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[deps.ArrayInterface]]
+deps = ["Compat", "IfElse", "LinearAlgebra", "Requires", "SparseArrays", "Static"]
+git-tree-sha1 = "1bdcc02836402d104a46f7843b6e6730b1948264"
+uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+version = "4.0.2"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.BenchmarkTools]]
+deps = ["JSON", "Logging", "Printf", "Profile", "Statistics", "UUIDs"]
+git-tree-sha1 = "940001114a0147b6e4d10624276d56d531dd9b49"
+uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+version = "1.2.2"
+
+[[deps.Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "44c37b4636bc54afac5c574d2d02b625349d6582"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "3.41.0"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[deps.Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[deps.DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.8.6"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[deps.ExprTools]]
+git-tree-sha1 = "56559bbef6ca5ea0c0818fa5c90320398a6fbf8d"
+uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
+version = "0.1.8"
+
+[[deps.IfElse]]
+git-tree-sha1 = "debdd00ffef04665ccbb3e150747a77560e8fad1"
+uuid = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
+version = "0.1.1"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.JLLWrappers]]
+deps = ["Preferences"]
+git-tree-sha1 = "abc9885a7ca2052a736a600f7fa66209f96506e1"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.4.1"
+
+[[deps.JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "8076680b162ada2a031f707ac7b4953e30667a37"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.2"
+
+[[deps.JSON3]]
+deps = ["Dates", "Mmap", "Parsers", "StructTypes", "UUIDs"]
+git-tree-sha1 = "7d58534ffb62cd947950b3aa9b993e63307a6125"
+uuid = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+version = "1.9.2"
+
+[[deps.LazyArtifacts]]
+deps = ["Artifacts", "Pkg"]
+uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+
+[[deps.LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.MPI]]
+deps = ["Distributed", "DocStringExtensions", "Libdl", "MPICH_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "Pkg", "Random", "Requires", "Serialization", "Sockets"]
+git-tree-sha1 = "d56a80d8cf8b9dc3050116346b3d83432b1912c0"
+uuid = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+version = "0.19.2"
+
+[[deps.MPICH_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "4b754a51cec47b0366056efcf6e19d95b2ecb54c"
+uuid = "7cb0a576-ebde-5e09-9194-50597f1243b4"
+version = "4.0.0+0"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[deps.MicrosoftMPI_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "a16aa086d335ed7e0170c5265247db29172af2f9"
+uuid = "9237b28f-5490-5468-be7b-bb81f5f5e6cf"
+version = "10.1.3+2"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[deps.OffsetArrays]]
+deps = ["Adapt"]
+git-tree-sha1 = "043017e0bdeff61cfbb7afeb558ab29536bbb5ed"
+uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+version = "1.10.8"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+
+[[deps.OpenMPI_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
+git-tree-sha1 = "6340586e076b2abd41f5ba1a3b9c774ec6b30fde"
+uuid = "fe0851c0-eecd-5654-98d4-656369965a5c"
+version = "4.1.2+0"
+
+[[deps.Parsers]]
+deps = ["Dates"]
+git-tree-sha1 = "0b5cfbb704034b5b4c1869e36634438a047df065"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.2.1"
+
+[[deps.PencilArrays]]
+deps = ["ArrayInterface", "JSON3", "LinearAlgebra", "MPI", "OffsetArrays", "Random", "Reexport", "Requires", "StaticArrays", "StaticPermutations", "Strided", "TimerOutputs", "VersionParsing"]
+path = ".."
+uuid = "0e08944d-e94e-41b1-9406-dcf66b6a9d2e"
+version = "0.14.1"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "2cf929d64681236a2e074ffafb8d568733d2e6af"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.2.3"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.Profile]]
+deps = ["Printf"]
+uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.2.2"
+
+[[deps.Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.3.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[deps.SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.Static]]
+deps = ["IfElse"]
+git-tree-sha1 = "d4da8b728580709d736704764e55d6ef38cb7c87"
+uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
+version = "0.5.3"
+
+[[deps.StaticArrays]]
+deps = ["LinearAlgebra", "Random", "Statistics"]
+git-tree-sha1 = "a635a9333989a094bddc9f940c04c549cd66afcf"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "1.3.4"
+
+[[deps.StaticPermutations]]
+git-tree-sha1 = "193c3daa18ff3e55c1dae66acb6a762c4a3bdb0b"
+uuid = "15972242-4b8f-49a0-b8a1-9ac0e7a1a45d"
+version = "0.3.0"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[deps.Strided]]
+deps = ["LinearAlgebra", "TupleTools"]
+git-tree-sha1 = "4d581938087ca90eab9bd4bb6d270edaefd70dcd"
+uuid = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
+version = "1.1.2"
+
+[[deps.StructTypes]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "d24a825a95a6d98c385001212dc9020d609f2d4f"
+uuid = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
+version = "1.8.1"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.TimerOutputs]]
+deps = ["ExprTools", "Printf"]
+git-tree-sha1 = "97e999be94a7147d0609d0b9fc9feca4bf24d76b"
+uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
+version = "0.5.15"
+
+[[deps.TupleTools]]
+git-tree-sha1 = "3c712976c47707ff893cf6ba4354aa14db1d8938"
+uuid = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
+version = "1.3.0"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.VersionParsing]]
+git-tree-sha1 = "58d6e80b4ee071f5efd07fda82cb9fbe17200868"
+uuid = "81def892-9a0e-5fdd-b105-ffc91e053289"
+version = "1.3.0"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/benchmarks/Project.toml
+++ b/benchmarks/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+PencilArrays = "0e08944d-e94e-41b1-9406-dcf66b6a9d2e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/benchmarks/grids.jl
+++ b/benchmarks/grids.jl
@@ -1,0 +1,133 @@
+using MPI
+using PencilArrays
+using BenchmarkTools
+using Random
+
+using PencilArrays.LocalGrids:
+    LocalRectilinearGrid, components
+
+MPI.Init()
+comm = MPI.COMM_WORLD
+MPI.Comm_rank(comm) == 0 || redirect_stdout(devnull)
+
+@inline ftest(u, x, y, z) = u * (x + 2y + z^2)
+
+function bench_eachindex!(v, u, grid)
+    for I ∈ eachindex(grid)
+        @inbounds v[I] = ftest(u[I], grid[I]...)
+    end
+    v
+end
+
+function bench_iterators!(v, u, grid)
+    for (n, xyz) ∈ zip(eachindex(u), grid)
+        @inbounds v[n] = ftest(u[n], xyz...)
+    end
+    v
+end
+
+function bench_rawcoords!(v, u, coords)
+    for (n, I) ∈ zip(eachindex(u), CartesianIndices(u))
+        @inbounds xyz = map(getindex, coords, Tuple(I))
+        @inbounds v[n] = ftest(u[n], xyz...)
+    end
+    v
+end
+
+function benchmark_pencil(pen)
+    println(pen, "\n")
+    dims = size(pen)
+
+    # Note: things are roughly twice as fast if one "collects" ranges into
+    # regular arrays.
+    coords_global = map(
+        xs -> collect(Float64, xs),
+        (
+            range(0, 1; length = dims[1]),
+            range(0, 1; length = dims[2]),
+            [n^2 for n = 1:dims[3]],
+        )
+    )
+
+    grid = localgrid(pen, coords_global)
+
+    coords_local = map(view, coords_global, range_local(pen, LogicalOrder()))
+    @assert components(grid) == coords_local
+
+    u = PencilArray{Float64}(undef, pen)
+    randn!(u)
+
+    v = similar(u)
+
+    print("- Broadcast: ")
+    @btime $v .= ftest.($u, $(grid.x), $(grid.y), $(grid.z))
+
+    vcopy = copy(v)
+
+    fill!(v, 0)
+    print("- Eachindex: ")
+    @btime bench_eachindex!($v, $u, $grid)
+    @assert v == vcopy
+
+    fill!(v, 0)
+    print("- Iterators: ")
+    @btime bench_iterators!($v, $u, $grid)
+    @assert v == vcopy
+
+    fill!(v, 0)
+    print("- Raw coords:")  # i.e. without localgrid
+    @btime bench_rawcoords!($v, $u, $coords_local)
+    @assert v == vcopy
+
+    nothing
+end
+
+dims = (60, 110, 21)
+perms = [NoPermutation(), Permutation(2, 3, 1)]
+
+for (n, perm) ∈ enumerate(perms)
+    s = perm == NoPermutation() ? "Without permutations" : "With permutations"
+    println("\n($n) ", s, "\n")
+    pen = Pencil(dims, comm; permute = perm)
+    benchmark_pencil(pen)
+end
+
+#=============================================================
+
+Benchmark results
+=================
+
+On Julia 1.7.2 + PencilArrays v0.15.0 and 1 MPI process.
+
+This is with --check-bounds=no.
+Without that flag, things are a bit slower for the "Iterators" and "Raw coords"
+cases, which probably means that there are some @inbounds missing somewhere in
+the code.
+
+(1) Without permutations
+
+Decomposition of 3D data
+    Data dimensions: (60, 110, 21)
+    Decomposed dimensions: (2, 3)
+    Data permutation: NoPermutation()
+    Array type: Array
+
+- Broadcast:   212.889 μs (0 allocations: 0 bytes)
+- Eachindex:   171.430 μs (0 allocations: 0 bytes)
+- Iterators:   182.775 μs (0 allocations: 0 bytes)
+- Raw coords:  205.575 μs (0 allocations: 0 bytes)
+
+(2) With permutations
+
+Decomposition of 3D data
+    Data dimensions: (60, 110, 21)
+    Decomposed dimensions: (2, 3)
+    Data permutation: Permutation(2, 3, 1)
+    Array type: Array
+
+- Broadcast:   216.302 μs (0 allocations: 0 bytes)
+- Eachindex:   175.397 μs (0 allocations: 0 bytes)
+- Iterators:   158.978 μs (0 allocations: 0 bytes)
+- Raw coords:  312.931 μs (0 allocations: 0 bytes)
+
+=============================================================#

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,8 @@ DocMeta.setdocmeta!(
     recursive=true,
 )
 
+doctest(PencilArrays; fix = false)
+
 function main()
     makedocs(;
         modules = [PencilArrays],

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -31,6 +31,7 @@ function main()
             "Library" => [
                 "Pencils.md",
                 "PencilArrays.md",
+                "LocalGrids.md",
                 "Transpositions.md",
                 "PencilIO.md",
                 "MPITopology.md",

--- a/docs/src/LocalGrids.md
+++ b/docs/src/LocalGrids.md
@@ -1,0 +1,95 @@
+```@meta
+CurrentModule = PencilArrays.LocalGrids
+```
+
+# Working with grids
+
+PencilArrays.jl includes functionality for conveniently working with the
+coordinates associated to a multidimensional domain.
+For this, the [`localgrid`](@ref) function can be used to construct an object
+describing the grid coordinates associated to the local MPI process.
+This object can be used to easily and efficiently perform operations that
+depend on the local coordinates.
+
+## Creating local grids
+
+As an example, say we are performing a 3D simulation on a [rectilinear
+grid](https://en.wikipedia.org/wiki/Regular_grid#Rectilinear_grid), so that
+the coordinates of a grid point are given by ``\bm{x}_{ijk} = (x_i, y_j, z_k)``
+where `x`, `y` and `z` are separate one-dimensional arrays.
+For instance:
+
+```@example LocalGrids
+Nx, Ny, Nz = 65, 17, 21
+xs = range(0, 1; length = Nx)
+ys = range(-1, 1; length = Ny)
+zs = range(0, 2; length = Nz)
+nothing # hide
+```
+
+Before continuing, let's create a domain decomposition configuration:
+
+```@example LocalGrids
+using MPI
+using PencilArrays
+
+MPI.Init()
+comm = MPI.COMM_WORLD
+
+pen = Pencil((Nx, Ny, Nz), comm)
+```
+
+Now, we can extract the local grid associated to the local MPI process:
+
+```@example LocalGrids
+grid = localgrid(pen, (xs, ys, zs))
+```
+
+Note that this example was run on a single MPI process, which makes things
+somewhat less interesting, but the same applies to more processes.
+With more than one process, the local grid is a subset of the global grid
+defined by the coordinates `(xs, ys, zs)`.
+
+## Using local grids
+
+The `grid` object just created can be used to operate with `PencilArray`s.
+In particular, say we want to initialise a `PencilArray` to a function that
+depends on the domain coordinates, ``u(x, y, z) = x + 2y + z^2``.
+This can be easily done using the broadcasting syntax (here we use the `@.`
+macro for convenience):
+
+```@example LocalGrids
+u = PencilArray{Float64}(undef, pen)  # construct PencilArray first
+@. u = grid.x + 2 * grid.y + grid.z^2
+nothing # hide
+```
+
+Here, `grid.x`, `grid.y` and `grid.z` are a convenient way of extracting the
+three components of the grid.
+Alternatively, one can use the syntax `grid[1]`, `grid[2]`, etc..., which is in
+particularly useful when working in dimensions higher than 3.
+
+Note that one could do the same as above using indexing instead of
+broadcasting:
+
+```@example LocalGrids
+for I ∈ eachindex(grid)
+    x, y, z = grid[I]
+    u[I] = x + 2y + z^2
+end
+```
+
+## API
+
+```@docs
+AbstractLocalGrid
+LocalRectilinearGrid
+localgrid
+components
+```
+
+## Index
+
+```@index
+Pages = ["LocalGrids.md"]
+```

--- a/docs/src/LocalGrids.md
+++ b/docs/src/LocalGrids.md
@@ -79,7 +79,7 @@ for I ∈ eachindex(grid)
 end
 ```
 
-## API
+## Library
 
 ```@docs
 AbstractLocalGrid

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -39,16 +39,20 @@ provides efficient and highly scalable distributed FFTs.
 
 - decomposition of arrays along an arbitrary subset of dimensions;
 
+- tools for conveniently and efficiently iterating over the [coordinates of
+  distributed multidimensional geometries](@ref Working-with-grids);
+
 - [transpositions](@ref Global-MPI-operations) between different decomposition
   configurations, using point-to-point and collective MPI communications;
 
-- zero-cost, convenient dimension permutations using [StaticPermutations](https://github.com/jipolanco/StaticPermutations.jl);
+- zero-cost, convenient dimension permutations using [StaticPermutations.jl](https://github.com/jipolanco/StaticPermutations.jl);
 
-- convenient [parallel I/O](@ref PencilIO_module) using either MPI-IO or the
-  [Parallel HDF5](https://portal.hdfgroup.org/display/HDF5/Parallel+HDF5) libraries;
+- convenient [parallel I/O](@ref PencilIO_module) of distributed arrays using
+  either MPI-IO or the [Parallel
+  HDF5](https://portal.hdfgroup.org/display/HDF5/Parallel+HDF5) libraries;
 
 - distributed FFTs and related transforms via the
-  [PencilFFTs](https://github.com/jipolanco/PencilFFTs.jl) package.
+  [PencilFFTs.jl](https://github.com/jipolanco/PencilFFTs.jl) package.
 
 ## Installation
 
@@ -88,6 +92,21 @@ parent(Ax)           # parent array holding the local data (here, an Array{Float
 size(Ax)             # total size of the array = (42, 31, 29)
 size_local(Ax)       # size of local part, e.g. (42, 8, 10) for a given process
 range_local(Ax)      # range of local part on global grid, e.g. (1:42, 16:23, 20:29)
+
+# Let's associate the dimensions to a global grid of coordinates (x_i, y_j, z_k)
+xs_global = range(0, 1;  length = dims_global[1])
+ys_global = range(0, 2;  length = dims_global[2])
+zs_global = range(0, 2π; length = dims_global[3])
+
+# Part of the grid associated to the local MPI process:
+grid = localgrid(pen_x, (xs_global, ys_global, zs_global))
+
+# This is convenient for example if we want to initialise the `Ax` array as
+# a function of the grid coordinates (x, y, z):
+@. Ax = grid.x + (2 * grid.y * cos(grid.z))
+
+# Alternatively (useful in higher dimensions):
+@. Ax = grid[1] + (2 * grid[2] * cos(grid[3]))
 
 # Create another pencil configuration, decomposing along dimensions (1, 3).
 # We could use the same constructor as before, but it's recommended to reuse the

--- a/src/LocalGrids/LocalGrids.jl
+++ b/src/LocalGrids/LocalGrids.jl
@@ -1,78 +1,30 @@
 module LocalGrids
 
-using ..Pencils
+import ..Permutations: permutation
+
+using Base.Broadcast
 using StaticPermutations
 
-export
-    localgrid
+export localgrid
 
 """
-    AbstractLocalGrid{N, P <: AbstractPermutation}
+    AbstractLocalGrid{N, Perm <: AbstractPermutation}
 
 Abstract type specifying the local portion of an `N`-dimensional grid.
 """
-abstract type AbstractLocalGrid{N, P <: AbstractPermutation} end
+abstract type AbstractLocalGrid{N, Perm <: AbstractPermutation} end
 
 Base.ndims(::Type{<:AbstractLocalGrid{N}}) where {N} = N
 Base.ndims(g::AbstractLocalGrid) = ndims(typeof(g))
-Pencils.permutation(g::AbstractLocalGrid) = g.perm
-coordinates(g::AbstractLocalGrid) = g.coords
+permutation(g::AbstractLocalGrid) = g.perm
 
 """
-    LocalRectilinearGrid{N, P} <: AbstractLocalGrid{N, P}
+    components(g::LocalRectilinearGrid) -> (xs, ys, zs, ...)
 
-Defines the local portion of a rectilinear grid in `N` dimensions.
-
-A rectilinear grid is represented by a set of orthogonal coordinates `(x, y, z, ...)`.
+Get coordinates associated to the current MPI process.
 """
-struct LocalRectilinearGrid{
-        N,
-        P,
-        LocalCoords <: Tuple{Vararg{AbstractVector, N}},
-    } <: AbstractLocalGrid{N, P}
-    perm   :: P
-    coords :: LocalCoords  # in logical order
-end
+components(g::AbstractLocalGrid) = g.coords
 
-function LocalRectilinearGrid(
-        p::Pencil{N}, coords_global::Tuple{Vararg{AbstractVector, N}},
-    ) where {N}
-    ranges = range_local(p, LogicalOrder())
-    coords_local = map(view, coords_global, ranges)
-    perm = permutation(p)
-    LocalRectilinearGrid(perm, coords_local)
-end
-
-function Base.show(io::IO, g::LocalRectilinearGrid{N, P}) where {N, P}
-    print(io, nameof(typeof(g)), "{$N, $P} with coordinates:")
-    map(enumerate(coordinates(g))) do (n, xs)
-        print(io, "\n ($n) $xs")
-    end
-end
-
-# For convenience when working with up to three dimensions.
-@inline function Base.getproperty(g::LocalRectilinearGrid, name::Symbol)
-    if ndims(g) ≥ 1 && name === :x
-        coordinates(g)[1]
-    elseif ndims(g) ≥ 2 && name === :y
-        coordinates(g)[2]
-    elseif ndims(g) ≥ 3 && name === :z
-        coordinates(g)[3]
-    else
-        getfield(g, name)
-    end
-end
-
-"""
-    localgrid(p::Pencil, (x_global, y_global, ...)) -> LocalRectilinearGrid
-
-Create a [`LocalRectilinearGrid`](@ref) from a decomposition configuration and
-from a set of orthogonal global coordinates `(x_global, y_global, ...)`.
-
-In this case, each `*_global` is an `AbstractVector` describing the coordinates
-along one dimension of the global grid.
-"""
-localgrid(p::Pencil, coords_global::Tuple{Vararg{AbstractVector}}) =
-    LocalRectilinearGrid(p, coords_global)
+include("rectilinear.jl")
 
 end

--- a/src/LocalGrids/LocalGrids.jl
+++ b/src/LocalGrids/LocalGrids.jl
@@ -1,0 +1,78 @@
+module LocalGrids
+
+using ..Pencils
+using StaticPermutations
+
+export
+    localgrid
+
+"""
+    AbstractLocalGrid{N, P <: AbstractPermutation}
+
+Abstract type specifying the local portion of an `N`-dimensional grid.
+"""
+abstract type AbstractLocalGrid{N, P <: AbstractPermutation} end
+
+Base.ndims(::Type{<:AbstractLocalGrid{N}}) where {N} = N
+Base.ndims(g::AbstractLocalGrid) = ndims(typeof(g))
+Pencils.permutation(g::AbstractLocalGrid) = g.perm
+coordinates(g::AbstractLocalGrid) = g.coords
+
+"""
+    LocalRectilinearGrid{N, P} <: AbstractLocalGrid{N, P}
+
+Defines the local portion of a rectilinear grid in `N` dimensions.
+
+A rectilinear grid is represented by a set of orthogonal coordinates `(x, y, z, ...)`.
+"""
+struct LocalRectilinearGrid{
+        N,
+        P,
+        LocalCoords <: Tuple{Vararg{AbstractVector, N}},
+    } <: AbstractLocalGrid{N, P}
+    perm   :: P
+    coords :: LocalCoords  # in logical order
+end
+
+function LocalRectilinearGrid(
+        p::Pencil{N}, coords_global::Tuple{Vararg{AbstractVector, N}},
+    ) where {N}
+    ranges = range_local(p, LogicalOrder())
+    coords_local = map(view, coords_global, ranges)
+    perm = permutation(p)
+    LocalRectilinearGrid(perm, coords_local)
+end
+
+function Base.show(io::IO, g::LocalRectilinearGrid{N, P}) where {N, P}
+    print(io, nameof(typeof(g)), "{$N, $P} with coordinates:")
+    map(enumerate(coordinates(g))) do (n, xs)
+        print(io, "\n ($n) $xs")
+    end
+end
+
+# For convenience when working with up to three dimensions.
+@inline function Base.getproperty(g::LocalRectilinearGrid, name::Symbol)
+    if ndims(g) ≥ 1 && name === :x
+        coordinates(g)[1]
+    elseif ndims(g) ≥ 2 && name === :y
+        coordinates(g)[2]
+    elseif ndims(g) ≥ 3 && name === :z
+        coordinates(g)[3]
+    else
+        getfield(g, name)
+    end
+end
+
+"""
+    localgrid(p::Pencil, (x_global, y_global, ...)) -> LocalRectilinearGrid
+
+Create a [`LocalRectilinearGrid`](@ref) from a decomposition configuration and
+from a set of orthogonal global coordinates `(x_global, y_global, ...)`.
+
+In this case, each `*_global` is an `AbstractVector` describing the coordinates
+along one dimension of the global grid.
+"""
+localgrid(p::Pencil, coords_global::Tuple{Vararg{AbstractVector}}) =
+    LocalRectilinearGrid(p, coords_global)
+
+end

--- a/src/LocalGrids/LocalGrids.jl
+++ b/src/LocalGrids/LocalGrids.jl
@@ -1,6 +1,7 @@
 module LocalGrids
 
 import ..Permutations: permutation
+using ..PermutedIndices
 
 using Base.Broadcast
 using StaticPermutations
@@ -19,7 +20,7 @@ Base.ndims(g::AbstractLocalGrid) = ndims(typeof(g))
 permutation(g::AbstractLocalGrid) = g.perm
 
 """
-    components(g::LocalRectilinearGrid) -> (xs, ys, zs, ...)
+    LocalGrids.components(g::LocalRectilinearGrid) -> (xs, ys, zs, ...)
 
 Get coordinates associated to the current MPI process.
 """

--- a/src/LocalGrids/LocalGrids.jl
+++ b/src/LocalGrids/LocalGrids.jl
@@ -4,6 +4,7 @@ import ..Permutations: permutation
 using ..PermutedIndices
 
 using Base.Broadcast
+using Base: @propagate_inbounds
 using StaticPermutations
 
 export localgrid

--- a/src/LocalGrids/rectilinear.jl
+++ b/src/LocalGrids/rectilinear.jl
@@ -1,0 +1,144 @@
+"""
+    LocalRectilinearGrid{N, Perm} <: AbstractLocalGrid{N, Perm}
+
+Defines the local portion of a rectilinear grid in `N` dimensions.
+
+A rectilinear grid is represented by a set of orthogonal coordinates `(x, y, z, ...)`.
+"""
+struct LocalRectilinearGrid{
+        N,
+        Perm <: AbstractPermutation,
+        LocalCoords <: Tuple{Vararg{AbstractVector, N}},
+    } <: AbstractLocalGrid{N, Perm}
+    coords :: LocalCoords  # in logical order
+    perm   :: Perm
+end
+
+"""
+    localgrid((xs, ys, ...), perm = NoPermutation()) -> LocalRectilinearGrid
+
+Create a [`LocalRectilinearGrid`](@ref) from a set of orthogonal coordinates
+`(xs, ys, ...)`, where each element is an `AbstractVector`.
+
+Optionally, one can pass a static permutation (as in `Permutation(2, 1, 3)`) to
+change the order in which the coordinates are iterated.
+"""
+function localgrid(
+        coords::Tuple{Vararg{AbstractVector}},
+        perm::AbstractPermutation = NoPermutation(),
+    )
+    LocalRectilinearGrid(coords, perm)
+end
+
+# Axes in logical order
+Base.axes(g::LocalRectilinearGrid) = map(xs -> axes(xs, 1), components(g))
+
+# These are needed for `collect`
+Base.length(g::LocalRectilinearGrid) = prod(xs -> length(xs), components(g))
+
+@generated function Base.eltype(
+        ::Type{<:LocalRectilinearGrid{N, P, VecTuple}}
+    ) where {N, P, VecTuple}
+    types = Tuple{map(eltype, VecTuple.parameters)...}
+    :( $types )
+end
+
+# We define this wrapper type to be able to control broadcasting on separate
+# grid components (x, y, ...).
+struct RectilinearCoords1D{
+        i,  # dimension of this coordinate
+        FullGrid <: LocalRectilinearGrid,  # dataset dimension
+        Coords <: AbstractVector,
+    }
+    grid :: FullGrid
+    data :: Coords
+    function RectilinearCoords1D(g::LocalRectilinearGrid, ::Val{i}) where {i}
+        data = components(g)[i]
+        new{i, typeof(g), typeof(data)}(g, data)
+    end
+end
+
+function Base.show(io::IO, xs::RectilinearCoords1D{i}) where {i}
+    print(io, "Component i = $i of ")
+    summary(io, xs.grid)
+    print(io, ": ", xs.data)
+    nothing
+end
+
+Base.getindex(g::LocalRectilinearGrid, i::Val) = RectilinearCoords1D(g, i)
+@inline Base.getindex(g::LocalRectilinearGrid, i::Int) = g[Val(i)]
+
+@inline function Base.getindex(
+        g::LocalRectilinearGrid{N}, inds::Vararg{Integer, N},
+    ) where {N}
+    @boundscheck checkbounds(CartesianIndices(axes(g)), inds...)
+    inds_perm = permutation(g) * inds
+    map((xs, i) -> @inbounds(xs[i]), components(g), inds_perm)
+end
+
+@inline Base.getindex(g::LocalRectilinearGrid, I::CartesianIndex) =
+    g[Tuple(I)...]
+
+@inline function Base.CartesianIndices(g::LocalRectilinearGrid)
+    inds = CartesianIndices(axes(g))
+    PermutedCartesianIndices(inds, permutation(g))
+end
+
+# This is used by eachindex(::LocalRectilinearGrid)
+Base.keys(g::LocalRectilinearGrid) = CartesianIndices(g)
+
+@inline function Base.iterate(g::LocalRectilinearGrid, state = nothing)
+    perm = permutation(g)
+    stuff = if state === nothing
+        # Create and advance actual iterator
+        coords_mem = perm * components(g)  # iterate in memory order
+        iter = Iterators.product(coords_mem...)
+        iterate(iter)
+    else
+        iter = first(state)
+        iterate(state...)
+    end
+    stuff === nothing && return nothing
+    x⃗_mem, next = stuff
+    x⃗_log = perm \ x⃗_mem  # current coordinate in logical order (x, y, z, ...)
+    x⃗_log, (iter, next)
+end
+
+function Broadcast.broadcastable(xs::RectilinearCoords1D{i}) where {i}
+    g = xs.grid
+    N = ndims(g)
+    perm = permutation(g)
+    data = xs.data
+    dims = ntuple(j -> j == i ? length(data) : 1, Val(N))
+    reshape(xs.data, perm * dims)
+end
+
+function Base.show(io::IO, g::LocalRectilinearGrid{N}) where {N}
+    print(io, nameof(typeof(g)), "{$N} with ")
+    perm = permutation(g)
+    isidentity(perm) || print(io, perm, " and ")
+    print(io, "coordinates:")
+    foreach(enumerate(components(g))) do (n, xs)
+        print(io, "\n ($n) $xs")
+    end
+    nothing
+end
+
+function Base.summary(io::IO, g::LocalRectilinearGrid)
+    N = ndims(g)
+    print(io, nameof(typeof(g)), "{$N}")
+    nothing
+end
+
+# For convenience when working with up to three dimensions.
+@inline function Base.getproperty(g::LocalRectilinearGrid, name::Symbol)
+    if ndims(g) ≥ 1 && name === :x
+        g[Val(1)]
+    elseif ndims(g) ≥ 2 && name === :y
+        g[Val(2)]
+    elseif ndims(g) ≥ 3 && name === :z
+        g[Val(3)]
+    else
+        getfield(g, name)
+    end
+end

--- a/src/LocalGrids/rectilinear.jl
+++ b/src/LocalGrids/rectilinear.jl
@@ -47,16 +47,17 @@ end
 # grid components (x, y, ...).
 struct RectilinearGridComponent{
         i,  # dimension of this coordinate
+        T,
         FullGrid <: LocalRectilinearGrid,  # dataset dimension
-        Coords <: AbstractVector,
-    }
+        Coords <: AbstractVector{T},
+    } <: AbstractVector{T}
     grid :: FullGrid
     data :: Coords
     @inline function RectilinearGridComponent(
             g::LocalRectilinearGrid, ::Val{i},
         ) where {i}
         data = components(g)[i]
-        new{i, typeof(g), typeof(data)}(g, data)
+        new{i, eltype(data), typeof(g), typeof(data)}(g, data)
     end
 end
 
@@ -66,6 +67,11 @@ function Base.show(io::IO, xs::RectilinearGridComponent{i}) where {i}
     print(io, ": ", xs.data)
     nothing
 end
+
+Base.IndexStyle(::Type{<:RectilinearGridComponent}) = IndexLinear()
+Base.parent(xs::RectilinearGridComponent) = xs.data
+Base.size(xs::RectilinearGridComponent) = size(parent(xs))
+@inline Base.getindex(xs::RectilinearGridComponent, i) = parent(xs)[i]
 
 @inline Base.getindex(g::LocalRectilinearGrid, i::Val) =
     RectilinearGridComponent(g, i)

--- a/src/PencilArrays.jl
+++ b/src/PencilArrays.jl
@@ -12,6 +12,9 @@ import LinearAlgebra
 include("Pencils/Pencils.jl")
 @reexport using .Pencils
 
+include("PermutedIndices/PermutedIndices.jl")
+using .PermutedIndices
+
 include("LocalGrids/LocalGrids.jl")
 @reexport using .LocalGrids
 

--- a/src/PencilArrays.jl
+++ b/src/PencilArrays.jl
@@ -12,6 +12,9 @@ import LinearAlgebra
 include("Pencils/Pencils.jl")
 @reexport using .Pencils
 
+include("LocalGrids/LocalGrids.jl")
+@reexport using .LocalGrids
+
 import .Pencils:
     get_comm,
     permutation,

--- a/src/PencilArrays.jl
+++ b/src/PencilArrays.jl
@@ -9,8 +9,8 @@ using TimerOutputs
 import Base: @propagate_inbounds
 import LinearAlgebra
 
-include("Pencils/Pencils.jl")
-@reexport using .Pencils
+include("Permutations.jl")
+import .Permutations: permutation
 
 include("PermutedIndices/PermutedIndices.jl")
 using .PermutedIndices
@@ -18,9 +18,11 @@ using .PermutedIndices
 include("LocalGrids/LocalGrids.jl")
 @reexport using .LocalGrids
 
+include("Pencils/Pencils.jl")
+@reexport using .Pencils
+
 import .Pencils:
     get_comm,
-    permutation,
     range_local,
     range_remote,
     size_local,
@@ -30,7 +32,7 @@ import .Pencils:
     typeof_array
 
 export PencilArray, GlobalPencilArray, PencilArrayCollection, ManyPencilArray
-export pencil
+export pencil, permutation
 export gather
 export global_view
 export ndims_extra, ndims_space, extra_dims, sizeof_global

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -1,5 +1,8 @@
 module Pencils
 
+import ..Permutations: permutation
+import ..LocalGrids
+
 using StaticPermutations
 
 using MPI
@@ -418,6 +421,22 @@ function to_local(p::Pencil{N}, global_inds::ArrayRegion{N},
         (first(rg) + δ):(last(rg) + δ)
     end :: ArrayRegion{N}
     order === MemoryOrder() ? (permutation(p) * ind) : ind
+end
+
+"""
+    localgrid(p::Pencil, (x_global, y_global, ...)) -> LocalRectilinearGrid
+
+Create a [`LocalRectilinearGrid`](@ref) from a decomposition configuration and
+from a set of orthogonal global coordinates `(x_global, y_global, ...)`.
+
+In this case, each `*_global` is an `AbstractVector` describing the coordinates
+along one dimension of the global grid.
+"""
+function LocalGrids.localgrid(p::Pencil, coords_global::Tuple{Vararg{AbstractVector}})
+    perm = permutation(p)
+    ranges = range_local(p, LogicalOrder())
+    coords_local = map(view, coords_global, ranges)
+    LocalGrids.localgrid(coords_local, perm)
 end
 
 end

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -83,12 +83,14 @@ Decomposition of 3D data
     Data dimensions: (4, 8, 12)
     Decomposed dimensions: (2, 3)
     Data permutation: NoPermutation()
+    Array type: Array
 
 julia> Pencil(topo, (4, 8, 12), (2, 3); permute = Permutation(3, 2, 1))
 Decomposition of 3D data
     Data dimensions: (4, 8, 12)
     Decomposed dimensions: (2, 3)
     Data permutation: Permutation(3, 2, 1)
+    Array type: Array
 
 ```
 
@@ -115,12 +117,14 @@ Decomposition of 3D data
     Data dimensions: (4, 8, 12)
     Decomposed dimensions: (2, 3)
     Data permutation: NoPermutation()
+    Array type: Array
 
 julia> Pencil((4, 8, 12), (1, ), MPI.COMM_WORLD)
 Decomposition of 3D data
     Data dimensions: (4, 8, 12)
     Decomposed dimensions: (1,)
     Data permutation: NoPermutation()
+    Array type: Array
 ```
 
 ---
@@ -259,9 +263,10 @@ _sort_dimensions(dims::Dims{N}) where {N} = Tuple(sort(SVector(dims)))
 
 Base.summary(io::IO, p::Pencil) = Base.showarg(io, p, true)
 
-function Base.showarg(io::IO, p::Pencil{N,M,P,B}, toplevel) where {N,M,P,B}
+function Base.showarg(io::IO, p::Pencil{N,M,P}, toplevel) where {N,M,P}
     toplevel || print(io, "::")
-    print(io, nameof(typeof(p)), "{$N, $M, $P, $B}")
+    A = typeof_array(p)
+    print(io, nameof(typeof(p)), "{$N, $M, $P, $A}")
 end
 
 function Base.show(io::IO, p::Pencil)

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -424,10 +424,12 @@ function to_local(p::Pencil{N}, global_inds::ArrayRegion{N},
 end
 
 """
-    localgrid(p::Pencil, (x_global, y_global, ...)) -> LocalRectilinearGrid
+    localgrid(p::Pencil, (x_global, y_global, ...))      -> LocalRectilinearGrid
+    localgrid(u::PencilArray, (x_global, y_global, ...)) -> LocalRectilinearGrid
 
-Create a [`LocalRectilinearGrid`](@ref) from a decomposition configuration and
-from a set of orthogonal global coordinates `(x_global, y_global, ...)`.
+Create a [`LocalRectilinearGrid`](@ref LocalGrids.LocalRectilinearGrid) from a
+decomposition configuration and from a set of orthogonal global coordinates
+`(x_global, y_global, ...)`.
 
 In this case, each `*_global` is an `AbstractVector` describing the coordinates
 along one dimension of the global grid.

--- a/src/Permutations.jl
+++ b/src/Permutations.jl
@@ -1,0 +1,7 @@
+module Permutations
+
+export permutation
+
+function permutation end
+
+end

--- a/src/PermutedIndices/PermutedIndices.jl
+++ b/src/PermutedIndices/PermutedIndices.jl
@@ -1,0 +1,90 @@
+module PermutedIndices
+
+using StaticPermutations
+
+export PermutedLinearIndices, PermutedCartesianIndices
+
+# Custom definitions of LinearIndices and CartesianIndices to take into account
+# index permutations.
+#
+# In particular, when array dimensions are permuted, the default
+# CartesianIndices do not iterate in memory order, making them suboptimal.
+# We try to workaround that by adding a custom definition of CartesianIndices.
+#
+# (TODO Better / cleaner way to do this??)
+
+struct PermutedLinearIndices{
+        N, L <: LinearIndices, Perm,
+    } <: AbstractArray{Int,N}
+    data :: L  # indices in permuted order
+    perm :: Perm
+    function PermutedLinearIndices(
+            ind::LinearIndices{N}, perm::Perm) where {N, Perm}
+        L = typeof(ind)
+        new{N, L, Perm}(ind, perm)
+    end
+end
+
+Base.length(L::PermutedLinearIndices) = length(L.data)
+Base.size(L::PermutedLinearIndices) = L.perm \ size(L.data)
+Base.axes(L::PermutedLinearIndices) = L.perm \ axes(L.data)
+Base.iterate(L::PermutedLinearIndices, args...) = iterate(L.data, args...)
+Base.lastindex(L::PermutedLinearIndices) = lastindex(L.data)
+
+@inline function Base.getindex(L::PermutedLinearIndices, i::Integer)
+    @boundscheck checkbounds(L.data, i)
+    @inbounds L.data[i]
+end
+
+# Input: indices in logical (unpermuted) order
+@inline function Base.getindex(
+        L::PermutedLinearIndices{N}, I::Vararg{Integer,N},
+    ) where {N}
+    J = L.perm * I
+    @boundscheck checkbounds(L.data, J...)
+    @inbounds L.data[J...]
+end
+
+struct PermutedCartesianIndices{
+        N, C <: CartesianIndices{N}, Perm,
+    } <: AbstractArray{CartesianIndex{N}, N}
+    data :: C     # indices in memory (permuted) order
+    perm :: Perm  # permutation (logical -> memory)
+    function PermutedCartesianIndices(ind::CartesianIndices{N},
+                                      perm::Perm) where {N, Perm}
+        C = typeof(ind)
+        new{N, C, Perm}(ind, perm)
+    end
+end
+
+Base.size(C::PermutedCartesianIndices) = C.perm \ size(C.data)
+Base.axes(C::PermutedCartesianIndices) = C.perm \ axes(C.data)
+
+@inline function Base.iterate(C::PermutedCartesianIndices, args...)
+    next = iterate(C.data, args...)
+    next === nothing && return nothing
+    I, state = next  # `I` has permuted indices
+    J = C.perm \ I   # unpermute indices
+    J, state
+end
+
+# Get i-th Cartesian index in memory (permuted) order.
+# Returns the Cartesian index in logical (unpermuted) order.
+@inline function Base.getindex(C::PermutedCartesianIndices, i::Integer)
+    @boundscheck checkbounds(C.data, i)
+    @inbounds I = C.data[i]  # convert linear to Cartesian index (relatively slow...)
+    C.perm \ I           # unpermute indices
+end
+
+# Not sure if this is what makes the most sense, but it's consistent with the
+# behaviour of CartesianIndices(::OffsetArray). In any case, this function is
+# mostly used for printing (it's used by show(::PermutedCartesianIndices)), and
+# almost never for actual computations.
+@inline function Base.getindex(
+        C::PermutedCartesianIndices{N}, I::Vararg{Integer,N},
+    ) where {N}
+    @boundscheck checkbounds(C, I...)
+    CartesianIndex(I)
+end
+
+end

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -534,3 +534,10 @@ typeof_ptr(A::AbstractArray) = typeof(pointer(A)).name.wrapper
 Get the type of array (without the element type) so it can be used as a constructor.
 """
 typeof_array(A::PencilArray) = typeof_array(parent(A))
+
+"""
+    localgrid(x::PencilArray, args...)
+
+Equivalent of `localgrid(pencil(x), args...)`.
+"""
+LocalGrids.localgrid(A::PencilArray, args...) = localgrid(pencil(A), args...)

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -302,15 +302,17 @@ Base.IndexStyle(::Type{<:PencilArray{T,N,A}} where {T,N}) where {A} =
 end
 
 # Linear indexing
-@propagate_inbounds @inline Base.getindex(x::PencilArray, i::Integer) =
+@propagate_inbounds function Base.getindex(x::PencilArray, i::Integer)
     parent(x)[i]
+end
 
-@propagate_inbounds @inline Base.setindex!(x::PencilArray, v, i::Integer) =
+@propagate_inbounds function Base.setindex!(x::PencilArray, v, i::Integer)
     parent(x)[i] = v
+end
 
 # Cartesian indexing: assume input indices are unpermuted, and permute them.
 # (This is similar to the implementation of PermutedDimsArray.)
-@propagate_inbounds @inline Base.getindex(
+@propagate_inbounds Base.getindex(
         x::PencilArray{T,N}, I::Vararg{Int,N}) where {T,N} =
     parent(x)[_genperm(x, I)...]
 
@@ -323,8 +325,8 @@ end
     M = ndims_space(x)
     E = ndims_extra(x)
     @assert M + E === N
-    J = ntuple(n -> I[n], Val(M))
-    K = ntuple(n -> I[M + n], Val(E))
+    J = ntuple(n -> @inbounds(I[n]), Val(M))
+    K = ntuple(n -> @inbounds(I[M + n]), Val(E))
     perm = permutation(x)
     ((perm * J)..., K...)
 end

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -71,10 +71,10 @@ julia> pen = Pencil((20, 10, 12), MPI.COMM_WORLD);
 julia> u = PencilArray{Float64}(undef, pen);
 
 julia> summary(u)
-"20×10×12 PencilArray{Float64, 3}(::Pencil{3, 2, NoPermutation})"
+"20×10×12 PencilArray{Float64, 3}(::Pencil{3, 2, NoPermutation, Array})"
 
 julia> PencilArray{Float64}(undef, pen, 4, 3) |> summary
-"20×10×12×4×3 PencilArray{Float64, 5}(::Pencil{3, 2, NoPermutation})"
+"20×10×12×4×3 PencilArray{Float64, 5}(::Pencil{3, 2, NoPermutation, Array})"
 
 ```
 """
@@ -217,10 +217,10 @@ julia> pen = Pencil((20, 10, 12), MPI.COMM_WORLD);
 julia> u = PencilArray{Float64}(undef, pen);
 
 julia> similar(u) |> summary
-"20×10×12 PencilArray{Float64, 3}(::Pencil{3, 2, NoPermutation})"
+"20×10×12 PencilArray{Float64, 3}(::Pencil{3, 2, NoPermutation, Array})"
 
 julia> similar(u, ComplexF32) |> summary
-"20×10×12 PencilArray{ComplexF32, 3}(::Pencil{3, 2, NoPermutation})"
+"20×10×12 PencilArray{ComplexF32, 3}(::Pencil{3, 2, NoPermutation, Array})"
 
 julia> similar(u, (4, 3, 8)) |> summary
 "4×3×8 Array{Float64, 3}"
@@ -229,7 +229,7 @@ julia> similar(u, (4, 3)) |> summary
 "4×3 Matrix{Float64}"
 
 julia> similar(u, ComplexF32) |> summary
-"20×10×12 PencilArray{ComplexF32, 3}(::Pencil{3, 2, NoPermutation})"
+"20×10×12 PencilArray{ComplexF32, 3}(::Pencil{3, 2, NoPermutation, Array})"
 
 julia> similar(u, ComplexF32, (4, 3)) |> summary
 "4×3 Matrix{ComplexF32}"
@@ -256,11 +256,12 @@ Decomposition of 3D data
     Data dimensions: (20, 10, 12)
     Decomposed dimensions: (1, 3)
     Data permutation: Permutation(2, 3, 1)
+    Array type: Array
 
 julia> v = similar(u, pen_v);
 
 julia> summary(v)
-"20×10×12 PencilArray{Float64, 3}(::Pencil{3, 2, Permutation{(2, 3, 1), 3}})"
+"20×10×12 PencilArray{Float64, 3}(::Pencil{3, 2, Permutation{(2, 3, 1), 3}, Array})"
 
 julia> pencil(v) === pen_v
 true
@@ -268,7 +269,7 @@ true
 julia> vint = similar(u, Int, pen_v);
 
 julia> summary(vint)
-"20×10×12 PencilArray{Int64, 3}(::Pencil{3, 2, Permutation{(2, 3, 1), 3}})"
+"20×10×12 PencilArray{Int64, 3}(::Pencil{3, 2, Permutation{(2, 3, 1), 3}, Array})"
 
 julia> pencil(vint) === pen_v
 true

--- a/src/cartesian_indices.jl
+++ b/src/cartesian_indices.jl
@@ -1,46 +1,5 @@
-# Custom definitions of LinearIndices and CartesianIndices to take into account
-# index permutations.
-#
-# In particular, when array dimensions are permuted, the default
-# CartesianIndices do not iterate in memory order, making them suboptimal.
-# We try to workaround that by adding a custom definition of CartesianIndices.
-#
-# (TODO Better / cleaner way to do this??)
-
 # We make LinearIndices(::PencilArray) return a PermutedLinearIndices, which
 # takes index permutation into account.
-struct PermutedLinearIndices{
-        N, L <: LinearIndices, Perm,
-    } <: AbstractArray{Int,N}
-    data :: L  # indices in permuted order
-    perm :: Perm
-    function PermutedLinearIndices(
-            ind::LinearIndices{N}, perm::Perm) where {N, Perm}
-        L = typeof(ind)
-        new{N, L, Perm}(ind, perm)
-    end
-end
-
-Base.length(L::PermutedLinearIndices) = length(L.data)
-Base.size(L::PermutedLinearIndices) = L.perm \ size(L.data)
-Base.axes(L::PermutedLinearIndices) = L.perm \ axes(L.data)
-Base.iterate(L::PermutedLinearIndices, args...) = iterate(L.data, args...)
-Base.lastindex(L::PermutedLinearIndices) = lastindex(L.data)
-
-@inline function Base.getindex(L::PermutedLinearIndices, i::Integer)
-    @boundscheck checkbounds(L.data, i)
-    @inbounds L.data[i]
-end
-
-# Input: indices in logical (unpermuted) order
-@inline function Base.getindex(
-        L::PermutedLinearIndices{N}, I::Vararg{Integer,N},
-    ) where {N}
-    J = L.perm * I
-    @boundscheck checkbounds(L.data, J...)
-    @inbounds L.data[J...]
-end
-
 Base.LinearIndices(A::PencilArray) =
     PermutedLinearIndices(LinearIndices(parent(A)), permutation(A))
 
@@ -53,48 +12,6 @@ end
 
 # We make CartesianIndices(::PencilArray) return a PermutedCartesianIndices,
 # which loops faster (in memory order) when there are index permutations.
-struct PermutedCartesianIndices{
-        N, C <: CartesianIndices{N}, Perm,
-    } <: AbstractArray{CartesianIndex{N}, N}
-    data :: C     # indices in memory (permuted) order
-    perm :: Perm  # permutation (logical -> memory)
-    function PermutedCartesianIndices(ind::CartesianIndices{N},
-                                      perm::Perm) where {N, Perm}
-        C = typeof(ind)
-        new{N, C, Perm}(ind, perm)
-    end
-end
-
-Base.size(C::PermutedCartesianIndices) = C.perm \ size(C.data)
-Base.axes(C::PermutedCartesianIndices) = C.perm \ axes(C.data)
-
-@inline function Base.iterate(C::PermutedCartesianIndices, args...)
-    next = iterate(C.data, args...)
-    next === nothing && return nothing
-    I, state = next  # `I` has permuted indices
-    J = C.perm \ I   # unpermute indices
-    J, state
-end
-
-# Get i-th Cartesian index in memory (permuted) order.
-# Returns the Cartesian index in logical (unpermuted) order.
-@inline function Base.getindex(C::PermutedCartesianIndices, i::Integer)
-    @boundscheck checkbounds(C.data, i)
-    @inbounds I = C.data[i]  # convert linear to Cartesian index (relatively slow...)
-    C.perm \ I           # unpermute indices
-end
-
-# Not sure if this is what makes the most sense, but it's consistent with the
-# behaviour of CartesianIndices(::OffsetArray). In any case, this function is
-# mostly used for printing (it's used by show(::PermutedCartesianIndices)), and
-# almost never for actual computations.
-@inline function Base.getindex(
-        C::PermutedCartesianIndices{N}, I::Vararg{Integer,N},
-    ) where {N}
-    @boundscheck checkbounds(C, I...)
-    CartesianIndex(I)
-end
-
 Base.CartesianIndices(A::PencilArray) =
     PermutedCartesianIndices(CartesianIndices(parent(A)), permutation(A))
 

--- a/test/arrays.jl
+++ b/test/arrays.jl
@@ -17,16 +17,16 @@ ug = global_view(u)
 
 @testset "Indices" begin
     for A in (u, ug)
-        for (n, I) in zip(LinearIndices(A), CartesianIndices(A))
-            @test A[n] === A[I]
+        @test all(zip(LinearIndices(A), CartesianIndices(A))) do (n, I)
+            A[n] === A[I]
         end
 
-        for (n, v) in pairs(IndexLinear(), A)
-            @test A[n] === v
+        @test all(pairs(IndexLinear(), A)) do (n, v)
+            A[n] === v
         end
 
-        for (I, v) in pairs(IndexCartesian(), A)
-            @test A[I] === v
+        @test all(pairs(IndexCartesian(), A)) do (I, v)
+            A[I] === v
         end
     end
 end

--- a/test/localgrid.jl
+++ b/test/localgrid.jl
@@ -1,0 +1,32 @@
+using MPI
+using PencilArrays
+using Test
+
+using PencilArrays.LocalGrids:
+    LocalRectilinearGrid
+
+MPI.Init()
+comm = MPI.COMM_WORLD
+
+perm = Permutation(2, 3, 1)
+@assert inv(perm) != perm
+
+dims = (6, 11, 21)
+pen = Pencil(dims, comm; permute = perm)
+
+coords_global = (
+    range(0, 1; length = dims[1]),
+    range(0, 1; length = dims[2]),
+    [n^2 for n = 1:dims[3]],
+)
+
+coords_local = @inferred localgrid(pen, coords_global)
+@test coords_local isa LocalRectilinearGrid{3}
+@test permutation(coords_local) === permutation(pen)
+@test ndims(coords_local) == 3
+@test (@inferred (g -> (g.x, g.y, g.z))(coords_local)) ===
+    LocalGrids.coordinates(coords_local)
+@test match(
+    r"^LocalRectilinearGrid{3, Permutation{.*}} with coordinates:",
+    repr(coords_local),
+) !== nothing

--- a/test/localgrid.jl
+++ b/test/localgrid.jl
@@ -43,6 +43,11 @@ pen = Pencil(dims, comm; permute = perm)
     @test match(
         r"^Component i = 2 of LocalRectilinearGrid\{3\}:", repr(grid.y),
     ) !== nothing
+    xl, yl, zl = @inferred components(grid)
+    @test grid.x == xl
+    @test all(i -> xl[i] == grid.x[i], eachindex(grid.x))
+    @test all(i -> yl[i] == grid.y[i], eachindex(grid.y))
+    @test all(i -> zl[i] == grid.z[i], eachindex(grid.z))
 
     # Broadcasting
     u = PencilArray{Float32}(undef, pen)

--- a/test/localgrid.jl
+++ b/test/localgrid.jl
@@ -3,7 +3,7 @@ using PencilArrays
 using Test
 
 using PencilArrays.LocalGrids:
-    LocalRectilinearGrid
+    LocalRectilinearGrid, components
 
 MPI.Init()
 comm = MPI.COMM_WORLD
@@ -14,19 +14,38 @@ perm = Permutation(2, 3, 1)
 dims = (6, 11, 21)
 pen = Pencil(dims, comm; permute = perm)
 
-coords_global = (
-    range(0, 1; length = dims[1]),
-    range(0, 1; length = dims[2]),
-    [n^2 for n = 1:dims[3]],
-)
+@testset "LocalRectilinearGrid" begin
+    coords_global = (
+        range(0, 1; length = dims[1]),
+        range(0, 1; length = dims[2]),
+        [n^2 for n = 1:dims[3]],  # these are Int
+    )
 
-coords_local = @inferred localgrid(pen, coords_global)
-@test coords_local isa LocalRectilinearGrid{3}
-@test permutation(coords_local) === permutation(pen)
-@test ndims(coords_local) == 3
-@test (@inferred (g -> (g.x, g.y, g.z))(coords_local)) ===
-    LocalGrids.coordinates(coords_local)
-@test match(
-    r"^LocalRectilinearGrid{3, Permutation{.*}} with coordinates:",
-    repr(coords_local),
-) !== nothing
+    grid = @inferred localgrid(pen, coords_global)
+    @test grid isa LocalRectilinearGrid{3}
+    @test permutation(grid) === permutation(pen)
+    @test ndims(grid) == 3
+    @test match(
+        r"^LocalRectilinearGrid\{3\} with Permutation\(.*\) and coordinates:",
+        repr(grid),
+    ) !== nothing
+
+    # Components
+    @inferred (g -> (g.x, g.y, g.z))(grid)
+    @inferred (g -> (g[1], g[2], g[3]))(grid)
+    @test match(
+        r"^Component i = 2 of LocalRectilinearGrid\{3\}:", repr(grid.y),
+    ) !== nothing
+
+    # Broadcasting
+    u = PencilArray{Float32}(undef, pen)
+    @test_nowarn @. u = grid.x * grid.y + grid.z
+
+    # Iteration
+    coords_col = @inferred collect(grid)
+    @test coords_col isa Vector
+    @test eltype(coords_col) === eltype(grid) ===
+        typeof(map(first, components(grid)))  # = Tuple{Float64, Float64, Int}
+
+    # Indexing
+end

--- a/test/pencils.jl
+++ b/test/pencils.jl
@@ -331,8 +331,8 @@ end
 pen2 = @inferred Pencil(pen1, decomp_dims=(1, 3), permute=Permutation(2, 3, 1))
 pen3 = @inferred Pencil(pen2, decomp_dims=(1, 2), permute=Permutation(3, 2, 1))
 
-@test match(r"Pencil{3, 2, NoPermutation, Vector{\w+}}", summary(pen1)) !== nothing
-@test match(r"Pencil{3, 2, Permutation{.*}, Vector{\w+}}", summary(pen2)) !== nothing
+@test match(r"Pencil{3, 2, NoPermutation, Array}", summary(pen1)) !== nothing
+@test match(r"Pencil{3, 2, Permutation{.*}, Array}", summary(pen2)) !== nothing
 
 println("Pencil 1: ", pen1, "\n")
 println("Pencil 2: ", pen2, "\n")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using PencilArrays
 include("permutations.jl")
 
 test_files = [
+    "localgrid.jl",
     "reductions.jl",
     "broadcast.jl",
     "array_types.jl",


### PR DESCRIPTION
This PR mainly defines a `localgrid(::Pencil, coords_global)` function that takes the coordinates `(xs, ys, ...)` of the global grid, and returns an object that contains the coordinates of the subdomain associated to the current MPI process.

For example:

```julia
using MPI
using PencilArrays

MPI.Init()
comm = MPI.COMM_WORLD
perm = Permutation(2, 3, 1)  # optional permutations are transparently taken care of

Nx, Ny, Nz = (60, 110, 210)
pen = Pencil((Nx, Ny, Nz), comm; permute = perm)

# Global domain coordinates
xs = range(0, 1; length = Nx)
ys = range(0, 1; length = Ny)
zs = [n^2 for n = 1:dims[3]]

# Create local grid
grid = localgrid(pen, (xs, ys, zs))

# The components can be obtained as (grid.x, grid.y, ...) for broadcasting:
u = PencilArray{Float64}(undef, pen)
@. u = grid.x * grid.y + grid.z

# Alternatively (useful when working with higher dimensions):
@. u = grid[1] * grid[2] + grid[3]

# Indexing and iteration also work:
for I ∈ eachindex(grid)
    x, y, z = grid[I]
    u[I] = x * y + z
end

# This is probably faster:
for (n, xyz) ∈ enumerate(grid)
    x, y, z = xyz
    u[n] = x * y + z
end
```

Things to do:

- [x] add documentation,
- [x] add benchmarks,

For later:

- [ ] make `grid[i, j, ...]` return `SVector` instead of tuple?
- [ ] allow broadcasting using the whole grid, as in `us ⋅ grid` (here `us` may be a `StructArray` of `PencilArray`s...),
- [ ] make `grid.x .+ grid.y` return a `PencilArray`?