### PR TITLE
Add support for reduction of multiple `PencilArray`s

### DIFF
--- a/src/reductions.jl
+++ b/src/reductions.jl
@@ -13,3 +13,11 @@ for (func, commutative) in [:mapreduce => true, :mapfoldl => false, :mapfoldr =>
         MPI.Allreduce(rlocal, op_mpi, get_comm(u))
     end
 end
+for (func, commutative) in [:mapreduce => true, :mapfoldl => false, :mapfoldr => false]
+    @eval function Base.$func(f::F, op::OP, u::PencilArray, v::PencilArray; kws...) where {F, OP}
+        rlocal = $func(f, op, parent(u), parent(v); kws...)
+        op_mpi = MPI.Op(op, typeof(rlocal); iscommutative = $commutative)
+        @assert get_comm(u) == get_comm(v)
+        MPI.Allreduce(rlocal, op_mpi, get_comm(u))
+    end
+end

--- a/src/reductions.jl
+++ b/src/reductions.jl
@@ -7,17 +7,22 @@
 # operations are not strictly performed from left to right (or from right to
 # left), since each process locally reduces first.
 for (func, commutative) in [:mapreduce => true, :mapfoldl => false, :mapfoldr => false]
-    @eval function Base.$func(f::F, op::OP, u::PencilArray; kws...) where {F, OP}
-        rlocal = $func(f, op, parent(u); kws...)
+    @eval function Base.$func(
+            f::F, op::OP, u::PencilArray, etc::Vararg{PencilArray}; kws...,
+        ) where {F, OP}
+        foreach(v -> _check_compatible_arrays(u, v), etc)
+        comm = get_comm(u)
+        ups = map(parent, (u, etc...))
+        rlocal = $func(f, op, ups...; kws...)
         op_mpi = MPI.Op(op, typeof(rlocal); iscommutative = $commutative)
-        MPI.Allreduce(rlocal, op_mpi, get_comm(u))
+        MPI.Allreduce(rlocal, op_mpi, comm)
     end
-end
-for (func, commutative) in [:mapreduce => true, :mapfoldl => false, :mapfoldr => false]
-    @eval function Base.$func(f::F, op::OP, u::PencilArray, v::PencilArray; kws...) where {F, OP}
-        rlocal = $func(f, op, parent(u), parent(v); kws...)
-        op_mpi = MPI.Op(op, typeof(rlocal); iscommutative = $commutative)
-        @assert get_comm(u) == get_comm(v)
-        MPI.Allreduce(rlocal, op_mpi, get_comm(u))
+
+    # Make things work with zip(u::PencilArray, v::PencilArray, ...)
+    @eval function Base.$func(
+            f::F, op::OP, z::Iterators.Zip{<:Tuple{Vararg{PencilArray}}}; kws...,
+        ) where {F, OP}
+        g(args...) = f(args)
+        $func(g, op, z.is...; kws...)
     end
 end

--- a/test/reductions.jl
+++ b/test/reductions.jl
@@ -2,17 +2,14 @@ using MPI
 using PencilArrays
 using Test
 
-MPI.Initialized() || MPI.Init()
+MPI.Init()
 
 comm = MPI.COMM_WORLD
 nprocs = MPI.Comm_size(comm)
 rank = MPI.Comm_rank(comm)
 myid = rank + 1
 
-# This can be simplified to `redirect_stdout(devnull)` on Julia ≥ 1.6.
-let dev_null = @static Sys.iswindows() ? "nul" : "/dev/null"
-    MPI.Comm_rank(comm) == 0 || redirect_stdout(open(dev_null, "w"))
-end
+rank == 0 || redirect_stdout(devnull)
 
 pen = Pencil((16, 32, 14), comm)
 u = PencilArray{Int32}(undef, pen)
@@ -25,6 +22,17 @@ fill!(u, 2myid)
     @test maximum(abs2, u) == (2nprocs)^2
     @test sum(u) === MPI.Allreduce(sum(parent(u)), +, comm)
     @test sum(abs2, u) === MPI.Allreduce(sum(abs2, parent(u)), +, comm)
+
+    @testset "Multiple PencilArrays" begin
+        û = @. u + im * u
+        v̂ = copy(û)
+        a = @inferred sum(abs2, û; init = zero(eltype(û)))  # `init` needed for inference when eltype(û) = Complex{Int32}...
+        # These should all be equivalent:
+        b = @inferred mapreduce((x, y) -> real(x * conj(y)), +, û, v̂)
+        c = @inferred sum(Base.splat((x, y) -> real(x * conj(y))), zip(û, v̂))
+        d = @inferred sum(xs -> real(xs[1] * conj(xs[2])), zip(û, v̂))
+        @test a == b == c == d
+    end
 
     # These exact equalities work because we're using integers.
     # They are not guaranteed to work with floats.


### PR DESCRIPTION
Small change to be able to do:
```julia
rr₂ = mapreduce((x,y)->real(x*conj(y)),+,r,r₂)
```
where `r` and `r₂` are `PencilArray`.

I guess there are much cleaner ways to do it...