### PR TITLE
Add definitions for Adapt.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PencilArrays"
 uuid = "0e08944d-e94e-41b1-9406-dcf66b6a9d2e"
 authors = ["Juan Ignacio Polanco <jipolanc@gmail.com> and contributors"]
-version = "0.16.0"
+version = "0.16.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Juan Ignacio Polanco <jipolanc@gmail.com> and contributors"]
 version = "0.16.0"
 
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -19,6 +20,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 VersionParsing = "81def892-9a0e-5fdd-b105-ffc91e053289"
 
 [compat]
+Adapt = "3"
 ArrayInterface = "5"
 JSON3 = "1.4"
 MPI = "0.19"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -49,6 +49,8 @@ function main()
     deploydocs(;
         repo = "github.com/jipolanco/PencilArrays.jl",
         forcepush = true,
+        # PRs deploy at https://jipolanco.github.io/PencilArrays.jl/previews/PR**
+        push_preview = true,
     )
 
     nothing

--- a/docs/src/Pencils.md
+++ b/docs/src/Pencils.md
@@ -195,6 +195,7 @@ size_local(::Pencil, etc...)
 length_global(::Pencil)
 length_local(::Pencil)
 to_local(::Pencil)
+similar(::Pencil)
 ```
 
 ## Index

--- a/src/PencilArrays.jl
+++ b/src/PencilArrays.jl
@@ -7,7 +7,8 @@ using StaticPermutations
 using TimerOutputs
 using Requires: @require
 
-import Base: @propagate_inbounds
+using Base: @propagate_inbounds
+import Adapt
 import LinearAlgebra
 
 include("Permutations.jl")

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -245,7 +245,20 @@ function Pencil(::Type{A}, args...; kws...) where {A <: AbstractArray}
     Pencil(args...; kws..., send_buf, recv_buf = similar(send_buf))
 end
 
-typeof_array(A::AT) where {AT<:AbstractArray} = typeof(A).name.wrapper
+# Strips array type:
+#   Array{Int, 3} -> Array
+#   Array{Int}    -> Array
+#   Array         -> Array
+@generated function typeof_array(::Type{A′}) where {A′ <: AbstractArray}
+    A = A′
+    while A isa UnionAll
+        A = A.body
+    end
+    T = A.name.wrapper
+    :($T)
+end
+
+typeof_array(A::AbstractArray) = typeof_array(typeof(A))
 typeof_array(p::Pencil) = typeof_array(p.send_buf)
 
 """

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -181,6 +181,23 @@ struct Pencil{
     # Timing information.
     timer :: TimerOutput
 
+    # This constructor is left undocumented and should never be called directly.
+    function Pencil(
+            topology::MPITopology{M}, size_global::Dims{N},
+            decomp_dims::Dims{M}, axes_all, perm::P,
+            send_buf::BufVector, recv_buf::BufVector, timer::TimerOutput,
+        ) where {M, N, P, BufVector}
+        @assert issorted(decomp_dims)
+        check_permutation(perm)
+        axes_local = axes_all[coords_local(topology)...]
+        axes_local_perm = perm * axes_local
+        new{N, M, P, BufVector}(
+            topology, size_global, decomp_dims,
+            axes_all, axes_local, axes_local_perm,
+            perm, send_buf, recv_buf, timer,
+        )
+    end
+
     function Pencil(
             topology::MPITopology{M}, size_global::Dims{N},
             decomp_dims::Dims{M} = default_decomposition(N, Val(M));
@@ -188,25 +205,23 @@ struct Pencil{
             send_buf = UInt8[], recv_buf = UInt8[],
             timer = TimerOutput(),
         ) where {N, M}
-        check_permutation(permute)
         _check_selected_dimensions(N, decomp_dims)
         decomp_dims = _sort_dimensions(decomp_dims)
         axes_all = get_axes_matrix(decomp_dims, topology.dims, size_global)
-        axes_local = axes_all[coords_local(topology)...]
-        axes_local_perm = permute * axes_local
-        P = typeof(permute)
-        BV = typeof(send_buf)
-        new{N,M,P,BV}(topology, size_global, decomp_dims, axes_all, axes_local,
-                      axes_local_perm, permute, send_buf, recv_buf, timer)
+        Pencil(
+            topology, size_global, decomp_dims, axes_all, permute,
+            send_buf, recv_buf, timer,
+        )
     end
 
-    function Pencil(p::Pencil{N,M};
-                    decomp_dims::Dims{M} = decomposition(p),
-                    size_global::Dims{N} = size_global(p),
-                    permute = permutation(p),
-                    timer::TimerOutput = timer(p),
-                    etc...,
-                   ) where {N, M}
+    function Pencil(
+            p::Pencil{N,M};
+            decomp_dims::Dims{M} = decomposition(p),
+            size_global::Dims{N} = size_global(p),
+            permute = permutation(p),
+            timer::TimerOutput = timer(p),
+            etc...,
+    ) where {N, M}
         Pencil(p.topology, size_global, decomp_dims;
                permute=permute, timer=timer,
                send_buf=p.send_buf, recv_buf=p.recv_buf,
@@ -232,6 +247,63 @@ end
 
 typeof_array(A::AT) where {AT<:AbstractArray} = typeof(A).name.wrapper
 typeof_array(p::Pencil) = typeof_array(p.send_buf)
+
+"""
+    similar(p::Pencil, [A = typeof_array(p)], [dims = size_global(p)])
+
+Returns a [`Pencil`](@ref) decomposition with global dimensions `dims` and with
+underlying array type `A`.
+
+Typically, `A` should be something like `Array` or `CuArray` (see
+[`Pencil`](@ref) for details).
+"""
+function Base.similar(
+        p::Pencil{N}, ::Type{A}, dims::Dims{N} = size_global(p),
+    ) where {A <: AbstractArray, N}
+    _similar(A, typeof_array(p), p, dims)
+end
+
+Base.similar(p::Pencil{N}, dims::Dims{N} = size_global(p)) where {N} =
+    similar(p, typeof_array(p), dims)
+
+# Case A === A′
+function _similar(
+        ::Type{A}, ::Type{A}, p::Pencil{N}, dims::Dims{N},
+    ) where {N, A <: AbstractArray}
+    @assert typeof_array(p) === A
+    if dims == size_global(p)
+        p  # avoid all copies
+    else
+        Pencil(p; size_global = dims)
+    end
+end
+
+# Case A !== A′ (→ change of array type)
+function _similar(
+        ::Type{A′}, ::Type{A}, p::Pencil{N}, dims::Dims{N},
+    ) where {N, A <: AbstractArray, A′ <: AbstractArray}
+    @assert typeof_array(p) === A
+
+    # We initialise the array with a single element to work around problem
+    # with CuArrays: if its length is zero, then the CuArray doesn't have a
+    # valid pointer.
+    send_buf = A′{UInt8}(undef, 1)
+    recv_buf = similar(send_buf)
+
+    if dims == size_global(p)
+        # Avoid recomputing (and allocating a new) `axes_all`, since it doesn't
+        # change in the new decomposition.
+        Pencil(
+            p.topology, dims, p.decomp_dims, p.axes_all,
+            p.perm, send_buf, recv_buf, p.timer,
+        )
+    else
+        Pencil(
+            p.topology, dims, p.decomp_dims;
+            permute = p.perm, send_buf, recv_buf, timer = p.timer,
+        )
+    end
+end
 
 function check_permutation(perm)
     isperm(perm) && return

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -137,6 +137,14 @@ function PencilArray{T}(init, pencil::Pencil, extra_dims::Vararg{Integer}) where
     PencilArray(pencil, A{T}(init, dims))
 end
 
+# Treat PencilArray similarly to other wrapper types.
+# https://github.com/JuliaGPU/Adapt.jl/blob/master/src/wrappers.jl
+function Adapt.adapt_structure(to, u::PencilArray)
+    A = typeof_array(to)
+    p = similar(pencil(u), A)  # create Pencil with possibly different array type
+    PencilArray(p, Adapt.adapt(to, parent(u)))
+end
+
 pencil_type(::Type{PencilArray{T,N,A,M,E,P}}) where {T,N,A,M,E,P} = P
 
 # This is called by `summary`.

--- a/test/adapt.jl
+++ b/test/adapt.jl
@@ -1,0 +1,44 @@
+using Adapt
+using MPI
+using PencilArrays
+using Test
+
+include("include/jlarray.jl")
+using .JLArrays
+
+MPI.Init()
+comm = MPI.COMM_WORLD
+rank = MPI.Comm_rank(comm)
+rank == 0 || redirect_stdout(devnull)
+
+pen = Pencil((12, 43), comm)
+u = PencilArray(pen, rand(Float64, size_local(pen)...))
+
+@testset "Adapt" begin
+    @testset "Float64 -> Float32" begin
+        @assert u isa PencilArray{Float64, 2}
+        @assert parent(u) isa Array{Float64, 2}
+        v = @inferred adapt(Array{Float32}, u)
+        @test v isa PencilArray{Float32, 2}  # wrapper type is preserved
+        @test parent(v) isa Array{Float32, 2}
+        @test u ≈ v
+    end
+
+    # Try changing array type (Array -> JLArray)
+    @testset "Array -> JLArray" begin
+        @assert Pencils.typeof_array(u) === Array
+
+        v = @inferred adapt(JLArray, u)
+        @test v isa PencilArray{Float64, 2}
+        @test Pencils.typeof_array(v) === JLArray
+        @test parent(v) isa JLArray{Float64, 2}
+        @test JLArray(parent(u)) == parent(v)
+
+        # Similar but changing element type
+        v = @inferred adapt(JLArray{Float32}, u)
+        @test v isa PencilArray{Float32, 2}
+        @test Pencils.typeof_array(v) === JLArray
+        @test parent(v) isa JLArray{Float32, 2}
+        @test JLArray(parent(u)) ≈ parent(v)
+    end
+end

--- a/test/pencils.jl
+++ b/test/pencils.jl
@@ -417,6 +417,31 @@ end
         @test length(p) === prod(size(p))
         @inferred (p -> p.send_buf)(p)
     end
+
+    @testset "similar" begin
+        p = pen2
+        # Case 1a: identical pencil
+        let q = @inferred similar(p)
+            @test q === p
+        end
+        # Case 1b: different dimensions
+        let q = @inferred similar(p, 2 .* size_global(p))
+            @test size_global(q) == 2 .* size_global(p)
+        end
+        # Case 2a: same dimensions but different array type
+        let q = @inferred similar(p, DummyArray)
+            @test q !== p
+            @test q.axes_all === p.axes_all  # array wasn't copied nor recomputed
+            @test size_global(q) == size_global(p)
+            @test Pencils.typeof_array(q) === DummyArray
+        end
+        # Case 2b: different dimensions and array type
+        let q = @inferred similar(p, DummyArray, 2 .* size_global(p))
+            @test q !== p
+            @test size_global(q) == 2 .* size_global(p)
+            @test Pencils.typeof_array(q) === DummyArray
+        end
+    end
 end
 
 @testset "PencilArray" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ test_files = [
     "arrays.jl",
     "pencils.jl",
     "array_interface.jl",
+    "adapt.jl",
     "io.jl",
     "ode.jl",
 ]


### PR DESCRIPTION
This PR defines `Adapt.adapt_structure` for `PencilArray`. This should help interfacing with GPU array types.

This PR also adds `similar(::Pencil, args...)`.