### PR TITLE
Allow unsorted list of decomposed directions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PencilArrays"
 uuid = "0e08944d-e94e-41b1-9406-dcf66b6a9d2e"
 authors = ["Juan Ignacio Polanco <jipolanc@gmail.com> and contributors"]
-version = "0.16.1"
+version = "0.17.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -238,7 +238,7 @@ struct Pencil{
             timer = TimerOutput(),
         ) where {N, M}
         _check_selected_dimensions(N, decomp_dims)
-        axes_all = get_axes_matrix(decomp_dims, topology.dims, size_global)
+        axes_all = generate_axes_matrix(decomp_dims, topology.dims, size_global)
         _Pencil(
             topology, size_global, decomp_dims, axes_all, permute,
             send_buf, recv_buf, timer,

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -159,11 +159,11 @@ struct Pencil{
 
     # Decomposition directions.
     # Example: for x-pencils, this is typically (2, 3, ..., N).
-    # Note that don't need to be sorted.
-    # The order matters when determining over how many processes a given
-    # dimension is distributed.
-    # This is in particular important for determining whether two Pencil's are
-    # compatible for transposing between them.
+    # Note that the directions don't need to be sorted.
+    # The order matters when determining over how many processes a given dimension is
+    # distributed.
+    # This is in particular important for determining whether two Pencil's are compatible
+    # for transposing between them.
     decomp_dims :: Dims{M}
 
     # Part of the array held by every process.
@@ -246,10 +246,9 @@ struct Pencil{
     end
 
     # TODO
-    # - automatically reorder decomp_dims to make sure that both pencils are
-    #   compatible for transpositions
-    # - throw error if it's not possible to make both pencils compatible for
-    #   transpositions?
+    # - automatically reorder decomp_dims to make sure that both pencils are compatible for
+    #   transpositions
+    # - throw error if it's not possible to make both pencils compatible for transpositions?
     function Pencil(
             p::Pencil{N,M};
             decomp_dims::Dims{M} = decomposition(p),

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -245,6 +245,11 @@ struct Pencil{
         )
     end
 
+    # TODO
+    # - automatically reorder decomp_dims to make sure that both pencils are
+    #   compatible for transpositions
+    # - throw error if it's not possible to make both pencils compatible for
+    #   transpositions?
     function Pencil(
             p::Pencil{N,M};
             decomp_dims::Dims{M} = decomposition(p),

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -157,8 +157,13 @@ struct Pencil{
     # These dimensions are *before* permutation by perm.
     size_global :: Dims{N}
 
-    # Decomposition directions (sorted in increasing order).
-    # Example: for x-pencils, this is (2, 3, ..., N).
+    # Decomposition directions.
+    # Example: for x-pencils, this is typically (2, 3, ..., N).
+    # Note that don't need to be sorted.
+    # The order matters when determining over how many processes a given
+    # dimension is distributed.
+    # This is in particular important for determining whether two Pencil's are
+    # compatible for transposing between them.
     decomp_dims :: Dims{M}
 
     # Part of the array held by every process.
@@ -214,7 +219,6 @@ struct Pencil{
             decomp_dims::Dims{M}, axes_all, perm::P,
             send_buf::BufVector, recv_buf::BufVector, timer::TimerOutput,
         ) where {M, N, P, BufVector}
-        @assert issorted(decomp_dims)
         check_permutation(perm)
         check_empty_dimension(topology, size_global, decomp_dims)
         axes_local = axes_all[coords_local(topology)...]
@@ -234,7 +238,6 @@ struct Pencil{
             timer = TimerOutput(),
         ) where {N, M}
         _check_selected_dimensions(N, decomp_dims)
-        decomp_dims = _sort_dimensions(decomp_dims)
         axes_all = get_axes_matrix(decomp_dims, topology.dims, size_global)
         _Pencil(
             topology, size_global, decomp_dims, axes_all, permute,
@@ -373,9 +376,6 @@ function _check_selected_dimensions(N, dims::Dims{M}) where M
     end
     nothing
 end
-
-# Use the `sort` method from StaticArrays and convert back to tuple.
-_sort_dimensions(dims::Dims{N}) where {N} = Tuple(sort(SVector(dims)))
 
 Base.summary(io::IO, p::Pencil) = Base.showarg(io, p, true)
 

--- a/src/Pencils/data_ranges.jl
+++ b/src/Pencils/data_ranges.jl
@@ -9,28 +9,27 @@ function local_data_range(p, P, N)
 end
 
 # "Complete" dimensions not specified in `dims` with ones.
-# Example: if N = 5, dims = (2, 3) and vals = (42, 12), this returns
-# (1, 42, 12, 1, 1).
+# Examples:
+# - if N = 5, dims = (2, 3) and vals = (42, 12), this returns (1, 42, 12, 1, 1).
+# - if N = 5, dims = (3, 2) and vals = (42, 12), this returns (1, 12, 42, 1, 1).
 function complete_dims(::Val{N}, dims::Dims{M}, vals::Dims{M}) where {N, M}
     @assert N >= M
-    i = 0
     vals_all = ntuple(Val(N)) do n
-        if findfirst(dims .== n) === nothing
+        i = findfirst(==(n), dims)
+        if i === nothing
             1  # this dimension is not included in `dims`, so we put a 1
         else
-            i += 1
             vals[i]
         end
     end
-    @assert i == M
     vals_all :: Dims{N}
 end
 
 # Get axes (array regions) owned by all processes in a given pencil
 # configuration.
-function get_axes_matrix(decomp_dims::Dims{M},
-                         proc_dims::Dims{M},
-                         size_global::Dims{N}) where {N, M}
+function generate_axes_matrix(
+        decomp_dims::Dims{M}, proc_dims::Dims{M}, size_global::Dims{N},
+    ) where {N, M}
     axes = Array{ArrayRegion{N}, M}(undef, proc_dims)
 
     # Number of processes in every direction, including those where

--- a/src/Transpositions/Transpositions.jl
+++ b/src/Transpositions/Transpositions.jl
@@ -39,11 +39,14 @@ The two pencil configurations must be compatible for transposition:
 
 - they must have the same global data size,
 
-- when written as a sorted tuple, the decomposed dimensions must be almost the
-  same, with at most one difference. For instance, if the input of a 3D dataset
-  is decomposed in `(2, 3)`, then the output may be decomposed in `(1, 3)`, but
-  not in `(1, 2)`. If the decomposed dimensions are the same, then no
-  transposition is performed, and data is just copied if needed.
+- the decomposed dimensions must be almost the same, with at most one
+  difference.
+  For instance, if the input of a 3D dataset is decomposed in `(2, 3)`, then the
+  output may be decomposed in `(1, 3)` or in `(2, 1)`, but not in `(1, 2)`.
+  **Note that the order of the decomposed dimensions (as passed to the `Pencil`
+  constructor) matters.**
+  If the decomposed dimensions are the same, then no transposition is performed,
+  and data is just copied if needed.
 
 The `src` and `dest` arrays may be aliased (they can share memory space).
 
@@ -163,9 +166,7 @@ function assert_compatible(p::Pencil, q::Pencil)
             " configurations. Got $(p.size_global) ≠ $(q.size_global)."))
     end
     # Check that decomp_dims differ on at most one value.
-    # Both are expected to be sorted.
     dp, dq = map(decomposition, (p, q))
-    @assert all(map(issorted, (dp, dq)))
     if sum(dp .!= dq) > 1
         throw(ArgumentError(
             "pencil decompositions must differ in at most one dimension. " *

--- a/test/pencils.jl
+++ b/test/pencils.jl
@@ -501,6 +501,12 @@ transpose_methods = (Transpositions.PointToPoint(),
         @test compare_distributed_arrays(u1, u2)
     end
 
+    # Test transpositions with unsorted decomp_dims
+    let pen_alt = @inferred Pencil(pen1, decomp_dims = (2, 1))
+        ualt = PencilArray{T}(undef, pen_alt)
+        transpose!(ualt, u1, method=method)
+        @test compare_distributed_arrays(u1, ualt)
+    end
 end
 
 # Test arrays with extra dimensions.

--- a/test/pencils.jl
+++ b/test/pencils.jl
@@ -501,7 +501,7 @@ transpose_methods = (Transpositions.PointToPoint(),
         @test compare_distributed_arrays(u1, u2)
     end
 
-    # Test transpositions with unsorted decomp_dims
+    # Test transpositions with unsorted decomp_dims (#57).
     let pen_alt = @inferred Pencil(pen1, decomp_dims = (2, 1))
         ualt = PencilArray{T}(undef, pen_alt)
         transpose!(ualt, u1, method=method)


### PR DESCRIPTION
This PR lifts the restriction that the `decomp_dims` argument to `Pencil` must be a list of *sorted* dimensions. For instance, `decomp_dims = (1, 3)` was allowed while `(3, 1)` was not.

In practice, this enables transpositions that weren't possible before. This is because, for two decompositions to be compatible for transpositions, their `decomp_dims` must differ by exactly one element (this is an algorithmic detail which basically simplifies the implementation and allows to minimise inter-process communications). So, `decomp_dims = (2, 3)` (data is local in `x`) has always been compatible with `decomp_dims = (1, 3)` (data is local in `y`). This PR enables the `decomp_dims = (2, 1)` (local in `z`) configuration which wasn't previously possible.

For example:

```julia
using MPI
using PencilArrays
using LinearAlgebra: transpose!
using Random

MPI.Init()
comm = MPI.COMM_WORLD
dims_global = (12, 14, 9)

# Create a 2D decomposition in which data is local in the `x` direction.
pen_x = Pencil(dims_global, (2, 3), comm)
ux = PencilArray{Float64}(undef, pen_x)
randn!(ux)

# Create another 2D decomposition in which data is local in `y`.
# (This has always been possible.)
pen_y = Pencil(pen_x; decomp_dims = (1, 3))
uy = PencilArray{Float64}(undef, pen_y)
transpose!(uy, ux)  # transpose between the two configurations

# Create a 2D decomposition in which data is local in `z`.
# To transpose from an `x`-local to a `z`-local decomposition, it was
# previously required to go through the intermediate `y`-local configuration.
# With this PR we can skip that step and do the following:
pen_z = Pencil(pen_x; decomp_dims = (2, 1))  # the order of elements in decomp_dims is important!
uz = PencilArray{Float64}(undef, pen_z)
transpose!(uz, ux)
```

Note that it should be possible to automate the selection of a "good" order of `decomp_dims` leading to compatible decompositions, but this is not done for now.
