### PR TITLE
Fix issues with transpositions on GPUs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PencilArrays"
 uuid = "0e08944d-e94e-41b1-9406-dcf66b6a9d2e"
 authors = ["Juan Ignacio Polanco <jipolanc@gmail.com> and contributors"]
-version = "0.17.4"
+version = "0.17.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Transpositions/Transpositions.jl
+++ b/src/Transpositions/Transpositions.jl
@@ -627,14 +627,14 @@ function _permutedims!(::Type{<:AbstractArray}, v::SubArray, src, perm)
         copyto!(v, src)
     else
         E = ndims(v) - length(perm)  # number of "extra dims"
-        iperm = inv(append(perm, Val(E)))
+        pperm = append(perm, Val(E))
         # On GPUs, if `src` is an AbstractGPUArray, then there is a `permutedims!`
         # implementation for GPUs (in GPUArrays.jl) if the destination is also
         # an AbstractGPUArray.
         # Note that AbstractGPUArray <: DenseArray, and `v` is generally not
         # dense, so we need an intermediate array for the destination.
-        tmp = similar(src, iperm * size(src))  # TODO avoid allocation!
-        permutedims!(tmp, src, Tuple(iperm))
+        tmp = similar(src, pperm * size(src))  # TODO avoid allocation!
+        permutedims!(tmp, src, Tuple(pperm))
         copyto!(v, tmp)
     end
     v

--- a/src/Transpositions/Transpositions.jl
+++ b/src/Transpositions/Transpositions.jl
@@ -248,8 +248,11 @@ function permute_local!(Ao::PencilArray{T,N},
     Ao
 end
 
-mpi_buffer(p::Ptr{T}, count) where {T} =
-    MPI.Buffer(p, Cint(count), MPI.Datatype(T))
+function mpi_buffer(buf::AbstractArray{T}, off, length) where {T}
+    inds = (off + 1):(off + length)
+    v = view(buf, inds)
+    MPI.Buffer(v)
+end
 
 # Transposition among MPI processes in a subcommunicator.
 # R: index of MPI subgroup (dimension of MPI Cartesian topology) along which the
@@ -407,8 +410,10 @@ end
 
 function make_buffer_info(::PointToPoint, (send_buf, recv_buf), Nproc)
     (
-        send_ptr = Ref(pointer(send_buf)),
-        recv_ptr = Ref(pointer(recv_buf)),
+        send_buf = send_buf,
+        recv_buf = recv_buf,
+        send_offset = Ref(0),
+        recv_offset = Ref(0),
     )
 end
 
@@ -432,22 +437,22 @@ function transpose_send_self!(::Alltoallv, n, reqs, buf_info)
 end
 
 function transpose_send_other!(
-        ::PointToPoint, buf_info, (length_send_n, length_recv_n),
+        ::PointToPoint, info, (length_send_n, length_recv_n),
         n, (send_req, recv_req), (rank, comm), ::Type{T}
     ) where {T}
     # Exchange data with the other process (non-blocking operations).
     # Note: data is sent and received with the permutation associated to Pi.
     tag = 42
     send_req[n] = MPI.Isend(
-        mpi_buffer(buf_info.send_ptr[], length_send_n),
+        mpi_buffer(info.send_buf, info.send_offset[], length_send_n),
         rank, tag, comm
     )
     recv_req[n] = MPI.Irecv!(
-        mpi_buffer(buf_info.recv_ptr[], length_recv_n),
+        mpi_buffer(info.recv_buf, info.recv_offset[], length_recv_n),
         rank, tag, comm
     )
-    buf_info.send_ptr[] += length_send_n * sizeof(T)
-    buf_info.recv_ptr[] += length_recv_n * sizeof(T)
+    info.send_offset[] += length_send_n
+    info.recv_offset[] += length_recv_n
     nothing
 end
 

--- a/test/array_types.jl
+++ b/test/array_types.jl
@@ -28,7 +28,10 @@ Base.pointer(u::TestArray) = pointer(u.data)
 Base.pointer(u::TestArray, n::Integer) = pointer(u.data, n)  # needed to avoid ambiguity
 Base.unsafe_wrap(::Type{TestArray}, p::Ptr, dims::Union{Integer, Dims}; kws...) =
     TestArray(unsafe_wrap(Array, p, dims; kws...))
+
 MPI.Buffer(u::TestArray) = MPI.Buffer(u.data)  # for `gather`
+Base.cconvert(::Type{MPI.MPIPtr}, u::TestArray{T}) where {T} =
+    reinterpret(MPI.MPIPtr, pointer(u))
 
 # A bit of type piracy to help tests pass.
 # Note that MPI.Buffer is defined for CuArray.

--- a/test/array_types.jl
+++ b/test/array_types.jl
@@ -66,9 +66,14 @@ MPI.Comm_rank(comm) == 0 || redirect_stdout(devnull)
         @test_nowarn randn!(u)
     end
 
-    px = @inferred Pencil(A, (20, 16), (1, ), comm)
+    px = @inferred Pencil(A, (20, 16, 4), (1, ), comm)
 
-    @testset "Permutation: $perm" for perm ∈ (NoPermutation(), Permutation(2, 1))
+    @testset "Permutation: $perm" for perm ∈ (NoPermutation(), Permutation(2, 3, 1))
+        if perm != NoPermutation()
+            # Make sure we're testing the more "interesting" case in which the
+            # permutation is not its own inverse.
+            @assert inv(perm) != perm
+        end
         py = @inferred Pencil(px; decomp_dims = (2, ), permute = perm)
         @test permutation(py) == perm
         @test @inferred(typeof_array(px)) === A


### PR DESCRIPTION
Fixes the following issues when transposing distributed CuArrays:

- sometimes the wrong permutation was applied to the output of a transpose
- MPI buffers cannot be created directly out of `CuPtr`s
- `gather` sometimes gave wrong results on distributed `CuArray`s