### PR TITLE
Define `MPI.Waitall!(::Transposition)` as deprecated

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PencilArrays"
 uuid = "0e08944d-e94e-41b1-9406-dcf66b6a9d2e"
 authors = ["Juan Ignacio Polanco <jipolanc@gmail.com> and contributors"]
-version = "0.17.8"
+version = "0.17.9"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Transpositions/Transpositions.jl
+++ b/src/Transpositions/Transpositions.jl
@@ -120,6 +120,14 @@ function MPI.Waitall(t::Transposition)
     nothing
 end
 
+function MPI.Waitall!(t::Transposition)
+    @warn """
+    MPI.Waitall!(t::Transposition) is deprecated and will be soon removed.
+    Use MPI.Waitall(t) instead (without the `!`).
+    """
+    MPI.Waitall(t)
+end
+
 """
     transpose!(t::Transposition; waitall=true)
     transpose!(dest::PencilArray{T,N}, src::PencilArray{T,N};

--- a/test/array_types.jl
+++ b/test/array_types.jl
@@ -88,6 +88,7 @@ MPI.Comm_rank(comm) == 0 || redirect_stdout(devnull)
             @test pencil(uy) === py
             tr = @inferred Transpositions.Transposition(uy, ux)
             transpose!(tr)
+            @test_logs (:warn, r"is deprecated") MPI.Waitall!(tr)
 
             # Verify transposition
             gx = @inferred Nothing gather(ux)


### PR DESCRIPTION
It was replaced by `MPI.Waitall(::Transposition)` in v0.17.8. We now re-include it as deprecated to avoid breaking codes using `Waitall!`.