### PR TITLE
`similar`: always return a `PencilArray`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+The format is based on [Keep a Changelog] and [Common Changelog].
+
+## [0.19.0] - 2023-07-14
+
+### Changed
+
+-   **Breaking:** change behaviour of `similar(u::PencilArray, [T], dims)` ([#83])
+
+    When the `dims` argument is passed, we now try to return a new `PencilArray` instead of another (non-distributed) array type. Since this is only possible when `dims` matches the array size, an error is now thrown if that is not the case. This allows things to play nicely with other packages such as [StructArrays.jl](https://github.com/JuliaArrays/StructArrays.jl), which in some cases end up calling `similar` with the `dims` argument.
+
+  [Keep a Changelog]: https://keepachangelog.com/en/1.1.0/
+  [Common Changelog]: https://common-changelog.org/
+  [#83]: https://github.com/jipolanco/PencilArrays.jl/pull/83

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PencilArrays"
 uuid = "0e08944d-e94e-41b1-9406-dcf66b6a9d2e"
 authors = ["Juan Ignacio Polanco <juan-ignacio.polanco@cnrs.fr> and contributors"]
-version = "0.18.1"
+version = "0.19.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,7 +17,7 @@ doctest(PencilArrays; fix = false)
 function main()
     makedocs(;
         modules = [PencilArrays],
-        authors = "Juan Ignacio Polanco <jipolanc@gmail.com> and contributors",
+        authors = "Juan Ignacio Polanco <juan-ignacio.polanco@cnrs.fr>",
         repo = "https://github.com/jipolanco/PencilArrays.jl/blob/{commit}{path}#L{line}",
         sitename = "PencilArrays.jl",
         format = Documenter.HTML(;

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -14,6 +14,8 @@ OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 StaticArrayInterface = "0d7ed370-da01-4f52-bd93-41d350b8b718"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/test/pencils.jl
+++ b/test/pencils.jl
@@ -107,17 +107,13 @@ function test_array_wrappers(p::Pencil, ::Type{T} = Float64) where {T}
             @test pencil(v) === pencil(u)
         end
 
-        let v = @inferred similar(u, (3, 4))
-            @test v isa Matrix
-            @test size(v) == (3, 4)
-            @test eltype(v) === eltype(u)
-        end
+        @test (@inferred similar(u, size(u))) isa PencilArray{T}
+        @test (@inferred similar(u, Int, size(u))) isa PencilArray{Int}
 
-        let v = @inferred similar(u, Int, (3, 4))
-            @test v isa Matrix
-            @test size(v) == (3, 4)
-            @test eltype(v) === Int
-        end
+        @test_throws DimensionMismatch similar(u, 12)
+        @test_throws DimensionMismatch similar(u, Int, 12)
+        @test_throws DimensionMismatch similar(u, size(u) .+ 1)
+        @test_throws DimensionMismatch similar(u, Int, size(u) .+ 1)
 
         let A = DummyArray{Int}(undef, size_local(p, MemoryOrder()))
             pdummy = Pencil(DummyArray, p)
@@ -127,14 +123,6 @@ function test_array_wrappers(p::Pencil, ::Type{T} = Float64) where {T}
             v = @inferred similar(u)
             @test typeof(v) === typeof(u)
             @test size(v) == size(u)
-
-            w = @inferred similar(u, (4, 2))
-            @test w isa DummyArray{Int,2}
-            @test size(w) == (4, 2)
-
-            z = @inferred similar(u, Float32, (3, 4, 2))
-            @test z isa DummyArray{Float32,3}
-            @test size(z) == (3, 4, 2)
         end
 
         # Test similar(u, [T], q::Pencil)


### PR DESCRIPTION
This PR changes the behaviour of `similar(u::PencilArray, [T], [dims])` when the `dims` argument is passed.

First note that we cannot construct a `PencilArray` which is "similar" to `u` but having different dimensions, since in that case we would need to generate a new `Pencil` configuration which is not supported.

For this reason, and to make sure that the return type doesn't depend on the value of `dims`, calling `similar` used to return a non-distributed array (most often a regular `Array`) whenever `dims` was passed.

Now, we instead make sure that `similar` always returns a `PencilArray`. This is in particular needed if one wants to combine PencilArray, StructArrays and DiffEq.jl. So, when `dims` is passed, we now throw an error if `dims` is different from the size of `u`.